### PR TITLE
Hub extension for remote deployment 

### DIFF
--- a/hub-configure-eks
+++ b/hub-configure-eks
@@ -97,7 +97,7 @@ echo "* Using AWS region: $AWS_REGION"
 AWS_ACCOUNT="$(aws $AWS_OPTS sts get-caller-identity --query 'Account' --output text)"
 STATE_BUCKET="$AWS_ACCOUNT.$domain_zone"
 
-if aws $AWS_OPTS s3api head-bucket --bucket="$STATE_BUCKET" 2>/dev/null; then
+if test -z $(aws $AWS_OPTS s3api head-bucket --bucket=$STATE_BUCKET 2>&1); then
   STATE_REGION="$(aws $AWS_OPTS s3api get-bucket-location \
     --bucket="$STATE_BUCKET" --query 'LocationConstraint' \
     | sed -e 's/null/us-east-1/g')"
@@ -130,12 +130,13 @@ if test -z "$domain_name" || test -n "$FORCE"; then
   # TODO: move this to the template (.hub/env/configure)
   cat <<EOF > "$envdir/$domain_name.env"
 # Name of stack with associated domoain name (provided by Agile Stacks)
+export STACK_PATH="\$(pwd)/.hub"
 export HUB_STACK_NAME="$(echo "$domain_name" | cut -d. -f1)"
 export HUB_DOMAIN_NAME="$domain_name"
 export HUB_DOMAIN_KEY="$(jq -r '.key' < "$tmpfile1")"
 # Deployment state and deployment plan
-export HUB_STATE_FILE="$hubdir/$domain_name.state"
-export HUB_ELABORATE_FILE="$hubdir/$domain_name.elaborate"
+export HUB_STATE_FILE="\$STACK_PATH/$domain_name.state"
+export HUB_ELABORATE_FILE="\$STACK_PATH/$domain_name.elaborate"
 # Name and region of S3 bucket to store deployment state
 export HUB_STATE_BUCKET="$STATE_BUCKET"
 export HUB_STATE_REGION=$STATE_REGION
@@ -145,7 +146,7 @@ export K8S_PROVIDER="eks"
 export CLOUD_PROVIDER="aws"
 export AWS_PROFILE="$AWS_PROFILE"
 export AWS_REGION="$AWS_REGION"
-export KUBECONFIG="$kubeconfig"
+export KUBECONFIG="\$STACK_PATH/env/$domain_name.kubeconfig"
 EOF
 
   $SILENT || cat << EOF

--- a/hub-remote-deploy
+++ b/hub-remote-deploy
@@ -82,7 +82,7 @@ spec:
   containers:
   - name: toolbox
     image: $IMAGE:$IMAGE_VERSION
-    command: ["bash", "-c", "hub extensions install && sleep 10000"]    
+    command: ["bash", "-c", "hub extensions install && sleep infinity"]    
     envFrom:
         - configMapRef:
             name: toolbox-env
@@ -92,19 +92,26 @@ EOF
 }
 
 deploy_toolbox() {
-    $SILENT || printf '\033[1mDeploying toolbox container\n\033[0m'
+    $SILENT || echo 'Deploying toolbox container'
 
     kubectl kustomize ${KUSTOMIZE_DIR} > "${KUSTOMIZE_DIR}/toolbox.yaml"    
     kubectl apply -f ${KUSTOMIZE_DIR}/toolbox.yaml
-    $SILENT || printf '\033[1mWaiting for toolbox to be deployed\033[0m'
-    while [[ $(kubectl -n $K8S_NAMESPACE get pods -l app=toolbox -l provider=agilestacks.com -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do 
-        $SILENT || printf '\033[1m.\033[0m' && sleep 1; 
+    $SILENT || printf 'Waiting for toolbox to be deployed: '
+    
+    local ELAPSED=0
+    while [[ $(kubectl -n $K8S_NAMESPACE get pods -l app=toolbox -l provider=agilestacks.com -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True"  ]]; do 
+        $SILENT || printf '.' && sleep 1;
+        (( ELAPSED++ ))
+        if [[ $ELAPSED -eq $TOOLBOX_TIMEOUT ]]; then
+            $SILENT || echo 'Timed-out toolbox deployment, please check deployment logs'
+            exit 1
+        fi 
     done
-    $SILENT || printf '\033[1m\n\033[0m'
+    $SILENT || printf '\n'
 }
 
 delete_toolbox() {
-    $SILENT || printf '\033[1mDeleting toolbox container\n\033[0m'
+    $SILENT || echo 'Deleting toolbox container'
     kubectl -n "$K8S_NAMESPACE" delete pod -l app=toolbox -l provider=agilestacks.com; 
     kubectl -n "$K8S_NAMESPACE"  delete cm -l app=toolbox -l provider=agilestacks.com; 
     kubectl -n "$K8S_NAMESPACE" delete clusterrolebindings.rbac.authorization.k8s.io -l app=toolbox -l provider=agilestacks.com; 
@@ -114,14 +121,14 @@ delete_toolbox() {
 
 
 upload_data() {
-    $SILENT || printf '\033[1mCopying Certified Stack data to toolbox\n\033[0m'
+    $SILENT || echo 'Copying data to toolbox'
     kubectl -n "$K8S_NAMESPACE" cp . toolbox:./
     kubectl -n "$K8S_NAMESPACE" cp ~/.aws toolbox:/root/
 }
 
 
 deploy_stack() {
-    $SILENT || printf '\033[1mDeploying Certified Stack from toolbox\033[0m'
+    $SILENT || echo 'Deploying stack from toolbox'
     kubectl -n "$K8S_NAMESPACE" exec -it toolbox -- bash -c "\
         rm -f .env &&\
         ln -s .hub/env/$HUB_DOMAIN_NAME.env .env &&\
@@ -139,6 +146,7 @@ IMAGE_VERSION=${IMAGE_VERSION:-latest}
 K8S_NAMESPACE=${K8S_NAMESPACE:-kube-system}
 DELETE_TOOLBOX=${K8S_NAMESPACE:-true}
 KUSTOMIZE_DIR=$(mktemp -d)
+TOOLBOX_TIMEOUT=${TOOLBOX_TIMEOUT:-600}
 
 while [ "$1" != "" ]; do
     case $1 in

--- a/hub-remote-deploy
+++ b/hub-remote-deploy
@@ -13,7 +13,7 @@ Parameters:
     -c --components       List of components to deploy
     -o --offset           Deploy starting with the given component
     -s  --silent          Suppress console outputs in favor of result codes
-    -p --no-precheck      Skip `hub ext aws status` command execution
+    -p --no-precheck      Skip `hub aws status` command execution
     -d --delete-toolbox   Deletes deployed toolbox 
     -k --keep-toolbox     Keeps toolbox deployed on kubernetes cluster
     --skip-guide          Suppress "What's next messages"
@@ -133,8 +133,8 @@ deploy_stack() {
         rm -f .env &&\
         ln -s .hub/env/$HUB_DOMAIN_NAME.env .env &&\
         source .env &&\
-        hub ext stack elaborate &&\
-        hub ext stack deploy $@
+        hub stack elaborate &&\
+        hub stack deploy $@
         "
 }
 

--- a/hub-remote-deploy
+++ b/hub-remote-deploy
@@ -1,0 +1,196 @@
+#!/bin/bash -e
+
+usage() {
+    cat << EOF
+
+Executes deployment of Certified Stack from kuberentes cluster
+
+Usage: 
+$ $(basename "$0") -c component1,component2
+Deploys deploys two components 
+
+Parameters:
+    -c --components       List of components to deploy
+    -o --offset           Deploy starting with the given component
+    -s  --silent          Suppress console outputs in favor of result codes
+    -p --no-precheck      Skip `hub ext aws status` command execution
+    -d --delete-toolbox   Deletes deployed toolbox 
+    -k --keep-toolbox     Keeps toolbox deployed on kubernetes cluster
+    --skip-guide          Suppress "What's next messages"
+    -V  --verbose         Verbose outputs for debug purpose
+    -h  --help            Print this message
+
+EOF
+}
+
+generate_manifests() {
+    trap "rm -rf $KUSTOMIZE_DIR" EXIT
+
+    envfile="$KUSTOMIZE_DIR/envfile"
+    env | grep -E '^(AWS_|GOOGLE_|AZURE_|TF_|TERM=|LANG=|LC_)' >"$envfile"
+    kustomize_manifest="$KUSTOMIZE_DIR/kustomization.yaml"
+
+    cat <<EOF > $kustomize_manifest
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+commonLabels:
+  app: toolbox
+  provider: agilestacks.com
+configMapGenerator:
+- name: toolbox-env
+  namespace: $K8S_NAMESPACE
+  env: envfile
+- name: user-group
+  namespace: $K8S_NAMESPACE
+  literals:    
+  - USER=$USER
+  - UID=$(id -u)
+  - GID=$(id -g)
+resources:
+- deployment.yaml
+EOF
+
+pod_manifest="$KUSTOMIZE_DIR/deployment.yaml"
+cat <<EOF > $pod_manifest
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: toolbox
+  namespace: $K8S_NAMESPACE
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: toolbox-sa
+subjects:
+- kind: ServiceAccount
+  name: toolbox
+  namespace: $K8S_NAMESPACE
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: toolbox
+  namespace: $K8S_NAMESPACE
+spec:
+  serviceAccountName: toolbox
+  containers:
+  - name: toolbox
+    image: $IMAGE:$IMAGE_VERSION
+    command: ["bash", "-c", "hub extensions install && sleep 10000"]    
+    envFrom:
+        - configMapRef:
+            name: toolbox-env
+        - configMapRef:
+            name: user-group
+EOF
+}
+
+deploy_toolbox() {
+    $SILENT || printf '\033[1mDeploying toolbox container\n\033[0m'
+
+    kubectl kustomize ${KUSTOMIZE_DIR} > "${KUSTOMIZE_DIR}/toolbox.yaml"    
+    kubectl apply -f ${KUSTOMIZE_DIR}/toolbox.yaml
+    $SILENT || printf '\033[1mWaiting for toolbox to be deployed\033[0m'
+    while [[ $(kubectl -n $K8S_NAMESPACE get pods -l app=toolbox -l provider=agilestacks.com -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do 
+        $SILENT || printf '\033[1m.\033[0m' && sleep 1; 
+    done
+    $SILENT || printf '\033[1m\n\033[0m'
+}
+
+delete_toolbox() {
+    $SILENT || printf '\033[1mDeleting toolbox container\n\033[0m'
+    kubectl -n "$K8S_NAMESPACE" delete pod -l app=toolbox -l provider=agilestacks.com; 
+    kubectl -n "$K8S_NAMESPACE"  delete cm -l app=toolbox -l provider=agilestacks.com; 
+    kubectl -n "$K8S_NAMESPACE" delete clusterrolebindings.rbac.authorization.k8s.io -l app=toolbox -l provider=agilestacks.com; 
+    kubectl -n "$K8S_NAMESPACE" delete sa -l app=toolbox -l provider=agilestacks.com
+}
+
+
+
+upload_data() {
+    $SILENT || printf '\033[1mCopying Certified Stack data to toolbox\n\033[0m'
+    kubectl -n "$K8S_NAMESPACE" cp . toolbox:./
+    kubectl -n "$K8S_NAMESPACE" cp ~/.aws toolbox:/root/
+}
+
+
+deploy_stack() {
+    $SILENT || printf '\033[1mDeploying Certified Stack from toolbox\033[0m'
+    kubectl -n "$K8S_NAMESPACE" exec -it toolbox -- bash -c "\
+        rm -f .env &&\
+        ln -s .hub/env/$HUB_DOMAIN_NAME.env .env &&\
+        source .env &&\
+        hub ext stack elaborate &&\
+        hub ext stack deploy $@
+        "
+}
+
+
+GUIDE=${GUIDE:-true}
+SILENT=${SILENT:-false}
+IMAGE=${IMAGE:-agilestacks/toolbox}
+IMAGE_VERSION=${IMAGE_VERSION:-latest}
+K8S_NAMESPACE=${K8S_NAMESPACE:-kube-system}
+DELETE_TOOLBOX=${K8S_NAMESPACE:-true}
+KUSTOMIZE_DIR=$(mktemp -d)
+
+while [ "$1" != "" ]; do
+    case $1 in
+        -p | --no-precheck ) 
+                            CLOUD_CHECK=false
+                            ;;
+        -c | --component )  shift
+                            HUB_DEPLOY_OPTS="$HUB_DEPLOY_OPTS -c $1"
+                            FULL_STACK=false
+                            CLOUD_CHECK=false
+                            ;;
+        -o | --offset )     shift
+                            HUB_DEPLOY_OPTS="$HUB_DEPLOY_OPTS -o $1"
+                            FULL_STACK=false
+                            CLOUD_CHECK=false
+                            ;;
+        -k | --keep-toolbox ) 
+                            DELETE_TOOLBOX=false
+                            ;;
+        -d | --delete-toolbox )       
+                            delete_toolbox
+                            exit
+                            ;;
+        -S | --silent )     SILENT=true
+                            exit
+                            ;;
+        -V | --verbose )    set -x
+                            ;;
+        -h | --help )       usage
+                            exit
+                            ;;
+        * )                 usage
+                            exit 1
+    esac
+    shift
+done
+
+export NOGUIDE SILENT
+
+# shellcheck disable=SC1091
+source .env
+
+
+if  test -z "${AWS_PROFILE}" && \
+    test -x "$(which aws)" && \
+    aws sts get-caller-identity > /dev/null 2>&1; then
+    AWS_PROFILE=$(aws configure list | awk  '$1 ~ /^profile$/ {print $2}')
+    export AWS_PROFILE
+fi
+
+generate_manifests
+deploy_toolbox
+upload_data
+deploy_stack
+$DELETE_TOOLBOX || delete_toolbox

--- a/hub-stack
+++ b/hub-stack
@@ -8,6 +8,7 @@ Usage: $(basename "$0") <sub command>
 
 Parameters:
     deploy          Deploy current stack
+    remotedeploy    Running deployment process using remote kubernetes cluster
     undeploy        Undeploy current stack
     ls              Show list components of this stack
     show            Show parameters of this stack

--- a/hub-stack
+++ b/hub-stack
@@ -35,6 +35,8 @@ while [ "$1" != "" ]; do
                   ;;
     elaborate )   $HUB stack elaborate $@
                   ;;
+    remotedeploy ) hub-remote-deploy $@
+                  ;;
     configure )   $HUB configure $@
                   ;;
     ls )          echo "Not yet implemented"


### PR DESCRIPTION
General overview:

1. Creates toolbox manifests
2. Deploys them
3. Copies current directory data & AWS folder
4. Fixes .env symlink on container
5. Executes elaborate on container
6. Executes deploy on container

Toolbox user management:
* When downloading stack data using CP or Rsync user/group permission  can updated to match system user
* Creating remote user on container may contain edge-cases for example: group & permission id might already exist on container