### PR TITLE
109 kustomize subpath

### DIFF
--- a/aws/pre-deploy
+++ b/aws/pre-deploy
@@ -19,20 +19,64 @@ printf "* Checking AWS connection... "
 aws sts get-caller-identity >/dev/null
 color green "ok"
 
+valid="1"
+HUB_STATE_BUCKET="$(dotenv get HUB_STATE_BUCKET)"
+if test -n "$HUB_STATE_BUCKET"; then
+  printf "* Checking presence of state bucket %s: " "$HUB_STATE_BUCKET"
+  if aws s3api head-bucket --bucket="$HUB_STATE_BUCKET" > /dev/null 2>&1; then
+    color h "exist"
+  else
+    color e << END
+not found
+
+You can create a bucket using the following command:
+
+  hubctl stack configure -r "aws"
+
+END
+    valid="0"
+  fi
+fi
+
 if test -n "$HUB_DOMAIN_NAME"; then
   if test -n "$HUB_DOMAIN_SECRET"; then
     printf "* Checking presence of Route 53 hosted zone %s... " "$HUB_DOMAIN_NAME"
     zone_id=$($r53_zoneid --domain-name "$HUB_DOMAIN_NAME")
     if test -z "$zone_id"; then
-      color e << EOF
+      color e << END
 not found
 
 You can create a hosted zone using the following command:
 
   hubctl stack configure -r "aws"
-EOF
-      exit 1
+END
+    valid="0"
     fi
     color g "$(basename "$zone_id")"
   fi
+fi
+
+RECURSIVE=${RECURSIVE:-0}
+if test "$RECURSIVE" = "0" -a "$valid" = "0"; then
+  color g << END
+* Running: hubctl stack configure -r "aws"
+  To refresh aws configuration
+END
+  hubctl stack configure -r "aws"
+  color g "* Running again pre-deploy hook: aws"
+  RECURSIVE=1 $0 "$@"
+  valid="1"
+fi
+
+if test "$valid" = "0"; then
+  color e << END
+Error: cannot continue with deployment due to missing requirements.
+
+Tip: ususally fixes the issues:
+
+  hubctl stack configure -r "aws"
+
+If not, please resolve the issues manually and re-run the deployment
+END
+  exit 1
 fi

--- a/bin/ask
+++ b/bin/ask
@@ -221,7 +221,7 @@ fi
 if test -z "$message"; then
   message="$ENV variable"
 elif test -n "$ENV"; then
-  message="$message, $ENV"
+  message="$message"
 fi
 
 export HUB_FILES DOT_ENV HUB_WORKDIR

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -153,9 +153,9 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
   HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
   count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
-  dst="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
+  target="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
   if test "$count" = "0"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$dst"
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$target"
   # elif test "$count" = "1"; then
   #   files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
   else
@@ -169,16 +169,15 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-      dst="$dst/$dest"
-      if test -f "$dst"; then
+      if test -f "$target/$dest"; then
         color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
         echo "  Extracting directory: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
-        mkdir -p "$dst"
-        cp -r "$temp/$src/" "$dst/"
+        mkdir -p "$target/$dest"
+        cp -r "$temp/$src/" "$target/$dest"
       elif test -f "$temp/$src"; then
         echo "  Extracting file: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
-        files copy "$temp/$src" "$dst"
+        files copy "$temp/$src" "$target/$dest"
       else
         ERR="$ERR\n  - Not found: $src"
         continue

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -96,6 +96,7 @@ case "$VERB" in
 esac
 
 HUB_DOMAIN_NAME=${HUB_DOMAIN_NAME:?"Required variable HUB_DOMAIN_NAME has not been defined"}
+HUB_KUSTOMIZE_TARBALL_DIR="${HUB_KUSTOMIZE_TARBALL_DIR:-kustomize}"
 # NAMESPACE=${NAMESPACE:?"Required variable DOMAIN_NAME has not been defined"}
 
 apply_k8s_resources_file() {
@@ -146,37 +147,38 @@ if test "$VERB" = "deploy"; then
   fi
 fi
 
+
 if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
   #shellcheck disable=SC2153
   HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
   count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
+  dst="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
   if test "$count" = "0"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
-  elif test "$count" = "1"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$dst"
+  # elif test "$count" = "1"; then
+  #   files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
   else
-    # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
-    rm -rf "$(pwd)/kustomize"
-    temp="$(mktemp)"
-    trap 'rm -rf $temp' EXIT
+    temp="$TEMP_DIR/content"
+    mkdir -p "$temp"
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$temp"
+    # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
     for subpath in $HUB_KUSTOMIZE_TARBALL_SUBPATHS; do
       src=$(echo "$subpath" | cut -d: -f1)
       dest=$(echo "$subpath" | cut -d: -f2)
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-      dst="$(pwd)/kustomize/$dest"
+      dst="$dst/$dest"
       if test -f "$dst"; then
         color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
-        echo "  Extracting directory: $src to kustomize/$dest"
+        echo "  Extracting directory: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
         mkdir -p "$dst"
         cp -r "$temp/$src/" "$dst/"
       elif test -f "$temp/$src"; then
-        echo "  Extracting file: $src to kustomize/$dest"
-        cp "$temp/$src" "$dst"
+        echo "  Extracting file: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
+        files copy "$temp/$src" "$dst"
       else
         ERR="$ERR\n  - Not found: $src"
         continue
@@ -194,10 +196,10 @@ if test -n "$HUB_KUSTOMIZE_RESOURCES"; then
   for res in $HUB_KUSTOMIZE_RESOURCES; do
     if echo "$res" | grep -e '^https\?://' >/dev/null 2>&1; then
       echo "  Downloading from: $res"
-      files download "$res" "$(pwd)/kustomize/$(basename "$res")"
+      files download "$res" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR/$(basename "$res")"
     elif test -f "$res"; then
       echo "  Copying from: $res"
-      files copy "$res" "$(pwd)/kustomize/$(basename "$res")"
+      files copy "$res" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR/$(basename "$res")"
     else
       color w "  Warning: file not found ($res)"
     fi

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -20,23 +20,45 @@ ident() {
   sed 's/^/  /'
 }
 
+apply_crd_file() {
+    max_di=$(yq e 'di' "$1" | tail -1)
+    for i in $(seq 0 "$max_di"); do
+        crd=$(yq e "select(di == $i).metadata.name" "$1")
+        if test -z "$crd" -o "$crd" = "null"; then
+            continue
+        fi
+        if $kubectl get crd "$crd" > /dev/null; then
+            echo "  $crd already exists"
+        else
+            $kubectl create -f "$1"
+        fi
+    done
+}
+
 OLD_NS="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
 TEMP_DIR=$(mktemp -d || exit 1)
 mkdir -p "$TEMP_DIR"
+ERR=""
 
 finalize() {
   rv=$?
   if test -n "$1"; then
     rm -rf "$1"
   fi
-  if test -n "$2"; then
-    echo "Restoring previous namespace: $2"
+  current_ns="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+  if test -n "$2" -a "$2" != "$current_ns"; then
+    echo "Setting previous namespace: $2"
     kubectl config set-context --current --namespace="$2"
+  fi
+  if test -n "$3"; then
+    color err << END
+  Error: $3
+END
   fi
   exit $rv
 }
 
-trap 'finalize $TEMP_DIR $OLD_NS' EXIT
+trap 'finalize "$TEMP_DIR" "$OLD_NS" "$ERR"' EXIT
 
 temp_file() {
   echo "$TEMP_DIR/$(head -c 32 < /dev/urandom | base64 | tr -dc '[:lower:]')"
@@ -135,15 +157,35 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
     trap 'rm -rf $temp' EXIT
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$temp"
     for subpath in $HUB_KUSTOMIZE_TARBALL_SUBPATHS; do
-      dst=${subpath#*:}
-      src=${subpath%?"$dst"}
-      dst="$(pwd)/kustomize/$dst"
-      mkdir -p "$dst"
-      cp -r "$temp/$src/" "$dst/"
+      src=$(echo "$subpath" | cut -d: -f1)
+      dest=$(echo "$subpath" | cut -d: -f2)
+      if test -z "$dest" -o "$dest" = "$src"; then
+        dest="$(basename "$src")"
+      fi
+
+      dst="$(pwd)/kustomize/$dest"
+      if test -f "$dst"; then
+        ERR="$ERR\n  - Destination file already exists: $dest"
+      elif test -d "$temp/$src"; then
+        echo "  Extracting directory: $src to kustomize/$dest"
+        mkdir -p "$dst"
+        cp -r "$temp/$src/" "$dst/"
+      elif test -f "$temp/$src"; then
+        echo "  Extracting file: $src to kustomize/$dest"
+        cp "$temp/$src" "$dst"
+      else
+        ERR="$ERR\n  - Not found: $src"
+        continue
+      fi
+
     done
   else
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
   fi
+fi
+
+if test -n "$err"; then
+  exit 1
 fi
 
 if test -n "$HUB_KUSTOMIZE_RESOURCES"; then

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -147,10 +147,15 @@ if test "$VERB" = "deploy"; then
 fi
 
 if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
+  #shellcheck disable=SC2153
+  HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
-  if test -n "$HUB_KUSTOMIZE_TARBALL_SUBPATH"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATH"
-  elif test -n "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"; then
+  count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
+  if test "$count" = "0"; then
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
+  elif test "$count" = "1"; then
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
+  else
     # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
     rm -rf "$(pwd)/kustomize"
     temp="$(mktemp)"
@@ -162,10 +167,9 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-
       dst="$(pwd)/kustomize/$dest"
       if test -f "$dst"; then
-        ERR="$ERR\n  - Destination file already exists: $dest"
+        color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
         echo "  Extracting directory: $src to kustomize/$dest"
         mkdir -p "$dst"
@@ -177,14 +181,11 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
         ERR="$ERR\n  - Not found: $src"
         continue
       fi
-
     done
-  else
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
   fi
 fi
 
-if test -n "$err"; then
+if test -n "$ERR"; then
   exit 1
 fi
 

--- a/tests/ask.bats
+++ b/tests/ask.bats
@@ -21,6 +21,8 @@ parameters:
   - name: test.hosts
     component: test3
     fromEnv: BATS_TEST_HOST
+  - name: bucket .accessKey
+    fromEnv: ARTIFACT_STORE_ACCESS_KEY
 EOF
 }
 
@@ -46,12 +48,12 @@ setup() {
 @test "ask env: should print messages if parameters need to set for different component discriminators" {
   run ask env "ARGO_HOST" -m "parameter ingress.hosts test1" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test1, ARGO"
+  assert_output --partial "* Setting parameter ingress.hosts test1"
   assert_output --partial "  ARGO_HOST saved"
 
   run ask env "KUBEFLOW_HOST" -m "parameter ingress.hosts test2" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test2, KUBEFLOW"
+  assert_output --partial "* Setting parameter ingress.hosts test2"
   assert_output --partial "  KUBEFLOW_HOST saved"
 }
 
@@ -63,12 +65,12 @@ setup() {
 @test "ask env: should print messages if parameters already set for different component discriminators" {
   run ask env "ARGO_HOST" -m "parameter ingress.hosts test1" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test1, ARGO_HOST"
+  assert_output --partial "* Setting parameter ingress.hosts test1"
   assert_output --partial "ARGO_HOST already set"
 
   run ask env "KUBEFLOW_HOST" -m "parameter ingress.hosts test2" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test2, KUBEFLOW_HOST"
+  assert_output --partial "* Setting parameter ingress.hosts test2"
   assert_output --partial "KUBEFLOW_HOST already set"
 }
 
@@ -76,15 +78,29 @@ setup() {
 @test "ask env: should print messages if parameter need to set without different component discriminators" {
   run ask env "BATS_TEST_HOST" -m "parameter test.hosts test3" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter test.hosts test3, BATS_TEST_HOST"
+  assert_output --partial "* Setting parameter test.hosts test3"
   assert_output --partial "BATS_TEST_HOST saved"
 }
 
 @test "ask env: should print messages if parameter already set without different component discriminators" {
   run ask env "BATS_TEST_HOST" -m "parameter test.hosts test3" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter test.hosts test3, BATS_TEST_HOST"
+  assert_output --partial "* Setting parameter test.hosts test3"
   assert_output --partial "BATS_TEST_HOST already set"
+}
+
+@test "ask env: should print messages if parameter need to set without the component" {
+  run ask env "ARTIFACT_STORE_ACCESS_KEY" -m "parameter test.hosts " +empty -d "$DOTENV_FILE" -ask-env --non-interactive
+  assert_success
+  assert_output --partial "* Setting parameter test.hosts"
+  assert_output --partial "ARTIFACT_STORE_ACCESS_KEY saved"
+}
+
+@test "ask env: should print messages if parameter already set without the component" {
+  run ask env "ARTIFACT_STORE_ACCESS_KEY" -m "parameter test.hosts " +empty -d "$DOTENV_FILE" -ask-env --non-interactive
+  assert_success
+  assert_output --partial "* Setting parameter test.hosts"
+  assert_output --partial "ARTIFACT_STORE_ACCESS_KEY already set"
 }
 
 teardown_file() {


### PR DESCRIPTION
This PR closes usability tweaks for `kustomize` extension #109 

- [x] Fixed broken CRD download for `kustomize`
- [x] Allows user to specify file in  parameter referenced by `HUB_KUSTOMIZE_TARBALL_SUBPATHS`  
- [x] Allows user to skip destination prefixed by `:` symbol in `HUB_KUSTOMIZE_TARBALL_SUBPATHS` in this case destination will be resolved to `kustomize/$(basename $src)"
