### PR TITLE
115 cleanup route 53 for awsundeploy

### DIFF
--- a/aws/post-undeploy
+++ b/aws/post-undeploy
@@ -5,23 +5,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-usage() {
-  cat << EOF
-AWS parameters:
-  --aws-region               AWS Region (defaults to value from: AWS_REGION)
-  --aws-profile              AWS Profile (defaults to value from: AWS_PROFILE)
-EOF
-}
 
 r53_undeploy="$(files -e find-in-path aws/route53/undeploy)"
 r53_zoneid="$(files -e find-in-path aws/route53/zone-id)"
 
-echo "Starting AWS cleanup..."
+echo "Starting AWS cleanup... $HUB_DOMAIN_NAME"
 
 if test -n "$HUB_DOMAIN_NAME"; then
   zone_id=$($r53_zoneid --domain-name "$HUB_DOMAIN_NAME")
   if test -n "$zone_id"; then
-    echo "* Deleting Route53 zone $HUB_DOMAIN_NAME"
     $r53_undeploy --domain-name "$HUB_DOMAIN_NAME"
   fi
 fi

--- a/aws/pre-deploy
+++ b/aws/pre-deploy
@@ -5,6 +5,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 usage() {
   cat << EOF
 AWS parameters:

--- a/aws/pre-deploy
+++ b/aws/pre-deploy
@@ -19,20 +19,64 @@ printf "* Checking AWS connection... "
 aws sts get-caller-identity >/dev/null
 color green "ok"
 
+valid="1"
+HUB_STATE_BUCKET="$(dotenv get HUB_STATE_BUCKET)"
+if test -n "$HUB_STATE_BUCKET"; then
+  printf "* Checking presence of state bucket %s: " "$HUB_STATE_BUCKET"
+  if aws s3api head-bucket --bucket="$HUB_STATE_BUCKET" > /dev/null 2>&1; then
+    color h "exist"
+  else
+    color e << END
+not found
+
+You can create a bucket using the following command:
+
+  hubctl stack configure -r "aws"
+
+END
+    valid="0"
+  fi
+fi
+
 if test -n "$HUB_DOMAIN_NAME"; then
   if test -n "$HUB_DOMAIN_SECRET"; then
     printf "* Checking presence of Route 53 hosted zone %s... " "$HUB_DOMAIN_NAME"
     zone_id=$($r53_zoneid --domain-name "$HUB_DOMAIN_NAME")
     if test -z "$zone_id"; then
-      color e << EOF
+      color e << END
 not found
 
 You can create a hosted zone using the following command:
 
   hubctl stack configure -r "aws"
-EOF
-      exit 1
+END
+    valid="0"
     fi
     color g "$(basename "$zone_id")"
   fi
+fi
+
+RECURSIVE=${RECURSIVE:-0}
+if test "$RECURSIVE" = "0" -a "$valid" = "0"; then
+  color g << END
+* Running: hubctl stack configure -r "aws"
+  To refresh aws configuration
+END
+  hubctl stack configure -r "aws"
+  color g "* Running again pre-deploy hook: aws"
+  RECURSIVE=1 $0 "$@"
+  valid="1"
+fi
+
+if test "$valid" = "0"; then
+  color e << END
+Error: cannot continue with deployment due to missing requirements.
+
+Tip: ususally fixes the issues:
+
+  hubctl stack configure -r "aws"
+
+If not, please resolve the issues manually and re-run the deployment
+END
+  exit 1
 fi

--- a/aws/route53/undeploy
+++ b/aws/route53/undeploy
@@ -19,6 +19,7 @@ Parameters:
 EOF
 }
 
+USE_FORCE="0"
 while [ "$1" != "" ]; do
     case $1 in
         --aws-region )    shift
@@ -28,7 +29,9 @@ while [ "$1" != "" ]; do
                           export AWS_PROFILE="$1"
                           ;;
         --domain-name )   shift
-                          HUB_DOMAIN_NAME="$1"
+                          domain_name="$1"
+                          ;;
+        -f |--force )     USE_FORCE="1"
                           ;;
         -h | --help )     usage
                           exit
@@ -37,7 +40,7 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if test -z "$HUB_DOMAIN_NAME"; then
+if test -z "$domain_name"; then
   usage
   exit 1
 fi
@@ -52,8 +55,17 @@ hosted_zone_id() {
     | xargs | cut -d " " -f1
 }
 
-printf "* Checking Route53 hosted zone %s... " "$HUB_DOMAIN_NAME";
-ZONE_ID=$(hosted_zone_id "$HUB_DOMAIN_NAME")
+strip_dot() {
+  echo "$1" | sed 's/\.$//'
+}
+
+domain_name="$(strip_dot "$domain_name")"
+if test -z "$HUB_DOMAIN_NAME"; then
+  HUB_DOMAIN_NAME="$domain_name"
+fi
+
+printf "* Checking Route53 hosted zone %s... " "$domain_name";
+ZONE_ID=$(hosted_zone_id "$domain_name")
 
 if test -z "$ZONE_ID"; then
   color w "not found"
@@ -61,6 +73,8 @@ if test -z "$ZONE_ID"; then
 fi
 color h "$(basename "$ZONE_ID")"
 
+# We check if current stack represented by HUB_DOMAIN_NAME
+# actually owns the zone by checking the presence of a tag
 tag_name="hubctl.io/stack/$HUB_DOMAIN_NAME"
 printf "* Checking presence of a tag %s: " "$tag_name"
 
@@ -72,8 +86,13 @@ tag_value="$(
   )"
 color h "${tag_value:-not found}"
 
-if test "$tag_value" != "owned"; then
-  color w "* Aborting due to hosted zone found but it is not owned by this stack"
+if test "$tag_value" != "owned" -a "$USE_FORCE" = "0"; then
+  color w <<END
+* Not deleting Route53 zone $HUB_DOMAIN_NAME because it is not owned by this stack
+  Please, delete it manually if you don't need it anymore.
+
+  Note: Route 53 owned by this stack should have tag: $tag_name="owned"
+END
   exit 0
 fi
 
@@ -96,7 +115,7 @@ for i in $(seq 0 "$(jq -r '.ResourceRecordSets | length - 1' "$temp/records.json
 }
 EOF
 
-    printf '%s' "  - Deleting record $type $name "
+    printf '%s' "  - Deleting $type $name "
     CHANGE=$(aws route53 change-resource-record-sets \
       --hosted-zone-id "$(basename "$ZONE_ID")" \
       --change-batch "file://$temp/change-$i.json" \

--- a/bin/ask
+++ b/bin/ask
@@ -221,7 +221,7 @@ fi
 if test -z "$message"; then
   message="$ENV variable"
 elif test -n "$ENV"; then
-  message="$message, $ENV"
+  message="$message"
 fi
 
 export HUB_FILES DOT_ENV HUB_WORKDIR

--- a/bin/ask
+++ b/bin/ask
@@ -34,10 +34,10 @@ Parameters
   -f  --file FILE                specify hubfile  (can repeat, defaults to HUB_FILES .env or environemnt variable)
   -m  --message TEXT             add a text message to display to the user
   -a  --alternative-param PARAM  alternative parameter name to search for
-  -d --dotenv FILE               locatin for dotenv file (defaults to DOT_ENV or .env)
-  --suggest   VALUE              value to use as a suggested default
+  -d  --dotenv FILE              locatin for dotenv file (defaults to DOT_ENV or .env)
   -t  --suggest-tag HASHTAG      tag name to apply for suggested value (default: suggested)
   -p  --priority HINTS           set hints priority (default see below)
+  -s  --suggest VALUE            value to use as a suggested default
   --non-interactive              set hints priority (defaults to TTY)
   --brief                        add brief user text (effectively replaces .brief of parameter)
 
@@ -105,14 +105,17 @@ if test -z "$HUB_WORKDIR"; then
   HUB_WORKDIR="$(dirname "$(files abspath .env)")"
 fi
 
+interactive=true
 if test "$HUB_INTERACTIVE" = "0"; then
-  HUB_INTERACTIVE=false
+  info="  Working in non-interactive mode (set by HUB_INTERACTIVE)"
+  interactive=false
 elif test -n "HUB_INTERACTIVE"; then
-  HUB_INTERACTIVE=true
+  interactive=true
 elif test -n "$(which tty)" && tty -s || echo "$-" | grep 'i'; then
-  HUB_INTERACTIVE=true
+  interactive=true
 else
-  HUB_INTERACTIVE=false
+  info="  Working in non-interactive mode (no tty)"
+  interactive=false
 fi
 
 while test -n "$1"; do
@@ -152,7 +155,7 @@ while test -n "$1"; do
       shift
     ;;
 
-    --suggest | --suggested )
+    -s | --suggest | --suggested )
       suggested_value="$2"
       shift
     ;;
@@ -163,7 +166,7 @@ while test -n "$1"; do
     ;;
 
     --non-interactive )
-      HUB_INTERACTIVE=false
+      interactive=false
     ;;
 
     +parameter | +random | +hubstate | +env | +history | +default | +empty )
@@ -220,8 +223,6 @@ fi
 
 if test -z "$message"; then
   message="$ENV variable"
-elif test -n "$ENV"; then
-  message="$message"
 fi
 
 export HUB_FILES DOT_ENV HUB_WORKDIR
@@ -305,7 +306,7 @@ if test "$hint" = "suggested" -a -n "$suggested_tag"; then
   hashtag="$suggested_tag"
 fi
 
-if ! $HUB_INTERACTIVE; then
+if ! $interactive; then
   VALUE="$hint_val"
 elif test -n "$hint" && ! contains "$hint" "$ask"; then
   VALUE="$hint_val"
@@ -318,6 +319,10 @@ else
   echo -n "  Enter value ("
   color -n b "$shorty"
   read -rp " #$hashtag): " VALUE
+fi
+
+if test -n "$info"; then
+  color --bold --color 0 "$info"
 fi
 
 if test -n "$VALUE" -a "$VALUE" != "$hint_val"; then

--- a/bin/color
+++ b/bin/color
@@ -11,7 +11,7 @@ usage() {
 Print colored message (if terminal supports colorings)
 
 Parameters:
-  -c --color COLOR_CODE   Use color with this code
+  +c --color COLOR_CODE   Use color with this code
   -n                      Do not print the trailing newline character
   +b --bold               Use bold text
   -e --stderr             Write output to stderr instead of stdout
@@ -54,9 +54,9 @@ while test -n "$1"; do
       set -x
       shift; continue
     ;;
-    -c | --color )
-      _tput setaf "$1"
+    -c | +c | --color )
       shift
+      _tput setaf "$1"
       shift; continue
     ;;
     -n )

--- a/env/configure
+++ b/env/configure
@@ -1,6 +1,6 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -70,5 +70,29 @@ fi
 for e in $(params listenv); do
   pname="$(params "$e" envvar | jq -cMr '.name? | select(.)')"
   pcomponent="$(params "$e" envvar | jq -cMr '.component? | select(.)')"
-  ask env "$e" -m "parameter $pname $pcomponent" +empty -d "$DOT_ENV" -d "$(files abspath ".env")" -ask-env
+  if test -n "$pcomponent"; then
+    msg="$pname for $pcomponent"
+  else
+    msg="$pname"
+  fi
+
+  if dotenv contains "$e"; then
+    printf '* Parameter %s using env %s: ' "$msg" "$e"
+    color g "set"
+    continue
+  fi
+
+  if test -n "$pcomponent"; then
+    ask env "$e" -m "parameter $msg" +empty -d "$DOT_ENV" -d "$(files abspath ".env")" -ask-env
+  else
+    ask env "$e" -m "parameter $pname" +empty -d "$DOT_ENV" -d "$(files abspath ".env")" -ask-env
+  fi
 done
+
+color green <<END
+  You can change variables by editing .env file
+
+  or delete variable and run to be prompted again:
+
+    hubctl stack configure -r env
+END

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -153,9 +153,9 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
   HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
   count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
-  dst="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
+  target="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
   if test "$count" = "0"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$dst"
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$target"
   # elif test "$count" = "1"; then
   #   files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
   else
@@ -169,16 +169,15 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-      dst="$dst/$dest"
-      if test -f "$dst"; then
+      if test -f "$target/$dest"; then
         color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
         echo "  Extracting directory: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
-        mkdir -p "$dst"
-        cp -r "$temp/$src/" "$dst/"
+        mkdir -p "$target/$dest"
+        cp -r "$temp/$src/" "$target/$dest"
       elif test -f "$temp/$src"; then
         echo "  Extracting file: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
-        files copy "$temp/$src" "$dst"
+        files copy "$temp/$src" "$target/$dest"
       else
         ERR="$ERR\n  - Not found: $src"
         continue

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -96,6 +96,7 @@ case "$VERB" in
 esac
 
 HUB_DOMAIN_NAME=${HUB_DOMAIN_NAME:?"Required variable HUB_DOMAIN_NAME has not been defined"}
+HUB_KUSTOMIZE_TARBALL_DIR="${HUB_KUSTOMIZE_TARBALL_DIR:-kustomize}"
 # NAMESPACE=${NAMESPACE:?"Required variable DOMAIN_NAME has not been defined"}
 
 apply_k8s_resources_file() {
@@ -146,37 +147,38 @@ if test "$VERB" = "deploy"; then
   fi
 fi
 
+
 if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
   #shellcheck disable=SC2153
   HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
   count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
+  dst="$(files abspath $HUB_KUSTOMIZE_TARBALL_DIR)"
   if test "$count" = "0"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
-  elif test "$count" = "1"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$dst"
+  # elif test "$count" = "1"; then
+  #   files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
   else
-    # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
-    rm -rf "$(pwd)/kustomize"
-    temp="$(mktemp)"
-    trap 'rm -rf $temp' EXIT
+    temp="$TEMP_DIR/content"
+    mkdir -p "$temp"
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$temp"
+    # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
     for subpath in $HUB_KUSTOMIZE_TARBALL_SUBPATHS; do
       src=$(echo "$subpath" | cut -d: -f1)
       dest=$(echo "$subpath" | cut -d: -f2)
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-      dst="$(pwd)/kustomize/$dest"
+      dst="$dst/$dest"
       if test -f "$dst"; then
         color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
-        echo "  Extracting directory: $src to kustomize/$dest"
+        echo "  Extracting directory: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
         mkdir -p "$dst"
         cp -r "$temp/$src/" "$dst/"
       elif test -f "$temp/$src"; then
-        echo "  Extracting file: $src to kustomize/$dest"
-        cp "$temp/$src" "$dst"
+        echo "  Extracting file: $src to $HUB_KUSTOMIZE_TARBALL_DIR/$dest"
+        files copy "$temp/$src" "$dst"
       else
         ERR="$ERR\n  - Not found: $src"
         continue
@@ -194,10 +196,10 @@ if test -n "$HUB_KUSTOMIZE_RESOURCES"; then
   for res in $HUB_KUSTOMIZE_RESOURCES; do
     if echo "$res" | grep -e '^https\?://' >/dev/null 2>&1; then
       echo "  Downloading from: $res"
-      files download "$res" "$(pwd)/kustomize/$(basename "$res")"
+      files download "$res" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR/$(basename "$res")"
     elif test -f "$res"; then
       echo "  Copying from: $res"
-      files copy "$res" "$(pwd)/kustomize/$(basename "$res")"
+      files copy "$res" "$(pwd)/$HUB_KUSTOMIZE_TARBALL_DIR/$(basename "$res")"
     else
       color w "  Warning: file not found ($res)"
     fi

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -20,23 +20,45 @@ ident() {
   sed 's/^/  /'
 }
 
+apply_crd_file() {
+    max_di=$(yq e 'di' "$1" | tail -1)
+    for i in $(seq 0 "$max_di"); do
+        crd=$(yq e "select(di == $i).metadata.name" "$1")
+        if test -z "$crd" -o "$crd" = "null"; then
+            continue
+        fi
+        if $kubectl get crd "$crd" > /dev/null; then
+            echo "  $crd already exists"
+        else
+            $kubectl create -f "$1"
+        fi
+    done
+}
+
 OLD_NS="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
 TEMP_DIR=$(mktemp -d || exit 1)
 mkdir -p "$TEMP_DIR"
+ERR=""
 
 finalize() {
   rv=$?
   if test -n "$1"; then
     rm -rf "$1"
   fi
-  if test -n "$2"; then
-    echo "Restoring previous namespace: $2"
+  current_ns="$(kubectl config view --minify --output 'jsonpath={..namespace}')"
+  if test -n "$2" -a "$2" != "$current_ns"; then
+    echo "Setting previous namespace: $2"
     kubectl config set-context --current --namespace="$2"
+  fi
+  if test -n "$3"; then
+    color err << END
+  Error: $3
+END
   fi
   exit $rv
 }
 
-trap 'finalize $TEMP_DIR $OLD_NS' EXIT
+trap 'finalize "$TEMP_DIR" "$OLD_NS" "$ERR"' EXIT
 
 temp_file() {
   echo "$TEMP_DIR/$(head -c 32 < /dev/urandom | base64 | tr -dc '[:lower:]')"
@@ -135,15 +157,35 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
     trap 'rm -rf $temp' EXIT
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$temp"
     for subpath in $HUB_KUSTOMIZE_TARBALL_SUBPATHS; do
-      dst=${subpath#*:}
-      src=${subpath%?"$dst"}
-      dst="$(pwd)/kustomize/$dst"
-      mkdir -p "$dst"
-      cp -r "$temp/$src/" "$dst/"
+      src=$(echo "$subpath" | cut -d: -f1)
+      dest=$(echo "$subpath" | cut -d: -f2)
+      if test -z "$dest" -o "$dest" = "$src"; then
+        dest="$(basename "$src")"
+      fi
+
+      dst="$(pwd)/kustomize/$dest"
+      if test -f "$dst"; then
+        ERR="$ERR\n  - Destination file already exists: $dest"
+      elif test -d "$temp/$src"; then
+        echo "  Extracting directory: $src to kustomize/$dest"
+        mkdir -p "$dst"
+        cp -r "$temp/$src/" "$dst/"
+      elif test -f "$temp/$src"; then
+        echo "  Extracting file: $src to kustomize/$dest"
+        cp "$temp/$src" "$dst"
+      else
+        ERR="$ERR\n  - Not found: $src"
+        continue
+      fi
+
     done
   else
     files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
   fi
+fi
+
+if test -n "$err"; then
+  exit 1
 fi
 
 if test -n "$HUB_KUSTOMIZE_RESOURCES"; then

--- a/hub-component-kustomize
+++ b/hub-component-kustomize
@@ -147,10 +147,15 @@ if test "$VERB" = "deploy"; then
 fi
 
 if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
+  #shellcheck disable=SC2153
+  HUB_KUSTOMIZE_TARBALL_SUBPATHS="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS $HUB_KUSTOMIZE_TARBALL_SUBPATH" | xargs)"
   echo "* Downloading component base from: $HUB_KUSTOMIZE_TARBALL_URL"
-  if test -n "$HUB_KUSTOMIZE_TARBALL_SUBPATH"; then
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATH"
-  elif test -n "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"; then
+  count="$(echo "$HUB_KUSTOMIZE_TARBALL_SUBPATHS" | tr ':' ' ' | wc -w | xargs)"
+  if test "$count" = "0"; then
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
+  elif test "$count" = "1"; then
+    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize" --tar-subpath "$HUB_KUSTOMIZE_TARBALL_SUBPATHS"
+  else
     # HUB_KUSTOMIZE_TARBALL_SUBPATHS is an array of paths divided by space (tarball_source_path:destination_path tarball_source_path:destination_path)
     rm -rf "$(pwd)/kustomize"
     temp="$(mktemp)"
@@ -162,10 +167,9 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
       if test -z "$dest" -o "$dest" = "$src"; then
         dest="$(basename "$src")"
       fi
-
       dst="$(pwd)/kustomize/$dest"
       if test -f "$dst"; then
-        ERR="$ERR\n  - Destination file already exists: $dest"
+        color warn "File $dest already exists"
       elif test -d "$temp/$src"; then
         echo "  Extracting directory: $src to kustomize/$dest"
         mkdir -p "$dst"
@@ -177,14 +181,11 @@ if test -n "$HUB_KUSTOMIZE_TARBALL_URL"; then
         ERR="$ERR\n  - Not found: $src"
         continue
       fi
-
     done
-  else
-    files download-tar "$HUB_KUSTOMIZE_TARBALL_URL" "$(pwd)/kustomize"
   fi
 fi
 
-if test -n "$err"; then
+if test -n "$ERR"; then
   exit 1
 fi
 

--- a/hub-stack-init
+++ b/hub-stack-init
@@ -484,9 +484,11 @@ if test -z "$HUB_STACK_NAME"; then
     HUB_STACK_NAME="$($params value "$hub_stack_name_param")"
   fi
   if test -z "$HUB_STACK_NAME" -a -n "$HUB_DOMAIN_NAME"; then
+    echo "* Using dns bubbles to generate domain name"
     HUB_STACK_NAME="$(echo "$HUB_DOMAIN_NAME" | cut -d "." -f1)"
   fi
   if test -z "$HUB_STACK_NAME"; then
+    echo "* Using dns bubbles to generate stack name"
     HUB_STACK_NAME="$($bubbles_new_name | cut -d "." -f1)"
   fi
 fi

--- a/tests/ask.bats
+++ b/tests/ask.bats
@@ -21,6 +21,8 @@ parameters:
   - name: test.hosts
     component: test3
     fromEnv: BATS_TEST_HOST
+  - name: bucket .accessKey
+    fromEnv: ARTIFACT_STORE_ACCESS_KEY
 EOF
 }
 
@@ -46,12 +48,12 @@ setup() {
 @test "ask env: should print messages if parameters need to set for different component discriminators" {
   run ask env "ARGO_HOST" -m "parameter ingress.hosts test1" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test1, ARGO"
+  assert_output --partial "* Setting parameter ingress.hosts test1"
   assert_output --partial "  ARGO_HOST saved"
 
   run ask env "KUBEFLOW_HOST" -m "parameter ingress.hosts test2" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test2, KUBEFLOW"
+  assert_output --partial "* Setting parameter ingress.hosts test2"
   assert_output --partial "  KUBEFLOW_HOST saved"
 }
 
@@ -63,12 +65,12 @@ setup() {
 @test "ask env: should print messages if parameters already set for different component discriminators" {
   run ask env "ARGO_HOST" -m "parameter ingress.hosts test1" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test1, ARGO_HOST"
+  assert_output --partial "* Setting parameter ingress.hosts test1"
   assert_output --partial "ARGO_HOST already set"
 
   run ask env "KUBEFLOW_HOST" -m "parameter ingress.hosts test2" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter ingress.hosts test2, KUBEFLOW_HOST"
+  assert_output --partial "* Setting parameter ingress.hosts test2"
   assert_output --partial "KUBEFLOW_HOST already set"
 }
 
@@ -76,15 +78,29 @@ setup() {
 @test "ask env: should print messages if parameter need to set without different component discriminators" {
   run ask env "BATS_TEST_HOST" -m "parameter test.hosts test3" +empty -d "$DOTENV_FILE" -ask-env --non-interactive
   assert_success
-  assert_output --partial "* Setting parameter test.hosts test3, BATS_TEST_HOST"
+  assert_output --partial "* Setting parameter test.hosts test3"
   assert_output --partial "BATS_TEST_HOST saved"
 }
 
 @test "ask env: should print messages if parameter already set without different component discriminators" {
   run ask env "BATS_TEST_HOST" -m "parameter test.hosts test3" +empty -d "$DOTENV_FILE" -ask-env
   assert_success
-  assert_output --partial "* Setting parameter test.hosts test3, BATS_TEST_HOST"
+  assert_output --partial "* Setting parameter test.hosts test3"
   assert_output --partial "BATS_TEST_HOST already set"
+}
+
+@test "ask env: should print messages if parameter need to set without the component" {
+  run ask env "ARTIFACT_STORE_ACCESS_KEY" -m "parameter test.hosts " +empty -d "$DOTENV_FILE" -ask-env --non-interactive
+  assert_success
+  assert_output --partial "* Setting parameter test.hosts"
+  assert_output --partial "ARTIFACT_STORE_ACCESS_KEY saved"
+}
+
+@test "ask env: should print messages if parameter already set without the component" {
+  run ask env "ARTIFACT_STORE_ACCESS_KEY" -m "parameter test.hosts " +empty -d "$DOTENV_FILE" -ask-env --non-interactive
+  assert_success
+  assert_output --partial "* Setting parameter test.hosts"
+  assert_output --partial "ARTIFACT_STORE_ACCESS_KEY already set"
 }
 
 teardown_file() {

--- a/tests/color.bats
+++ b/tests/color.bats
@@ -89,3 +89,24 @@ do_not_print_newline() {
     assert_success
     assert_output "$MESSAGE"
 }
+
+@test "color --color: should print message in color" {
+    run color --color 0 "$MESSAGE"
+    assert_success
+    assert_output "$MESSAGE"
+    run color -c 0 "$MESSAGE"
+    assert_success
+    assert_output "$MESSAGE"
+    run color +c 0 "$MESSAGE"
+    assert_success
+    assert_output "$MESSAGE"
+}
+
+@test "color --bold: should print message in bold" {
+    run color +b "$MESSAGE"
+    assert_success
+    assert_output "$MESSAGE"
+    run color --bold "$MESSAGE"
+    assert_success
+    assert_output "$MESSAGE"
+}


### PR DESCRIPTION
Fixes #114 This PR adds deployment hooks for `aws`

- [ ] Adds `aws/post-undeploy` hook to do R53 hosted zone cleanup
- [ ] Adds `aws/pre-deploy` hook to check if R53 hosted zone exist (race condition if previously cleaned up) 
- [ ] Fix for invalid parameter behaviour for `-c` 
