### PR TITLE
Some extensions ignore HUB_WORKDIR variable #113

### DIFF
--- a/aws-metering/before-deploy
+++ b/aws-metering/before-deploy
@@ -1,11 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 usage() {
   cat << EOF
@@ -37,13 +35,11 @@ if test "$VERBOSE" = "true"; then
   set -x
 fi
 
-if test ! -f ".env"; then
-  echo "Error: cannot find .env file. Please run 'hubctl configure'"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-set +a
 eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
-set -a
 
 if test -z "$AWS_PROFILE"; then
   export AWS_PROFILE
@@ -59,13 +55,13 @@ if test ! -f "$HUB_YAML"; then
 fi
 
 param() {
-  local rv
-  rv=$(
-      yq e -o=json $HUB_YAML | jq -r \
+  _param_rv=$(
+      #shellcheck disable=2086
+      yq e -o=json "$HUB_YAML" | jq -r \
       '.extensions.parameters? | select(.)[] | select(.name=="'$1'").value'
     )
-  if test -n "$rv"; then
-    echo "$rv"
+  if test -n "$_param_rv"; then
+    echo "$_param_rv"
   else
     echo "$2"
   fi

--- a/aws/configure
+++ b/aws/configure
@@ -292,7 +292,7 @@ fi
 STACK=${STACK:-$(basename "$(pwd)")}
 if test -z "$HUB_STATE"; then
   echo "* Setting hubctl state file location"
-  HUB_STATE_FILE=".hub/$HUB_DOMAIN_NAME.state"
+  HUB_STATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
   if ! $PREFER_LOCAL_STATE; then
     HUB_STATE_FILE="$HUB_STATE_FILE,s3://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/$STACK/hub.state"
   fi
@@ -300,7 +300,7 @@ if test -z "$HUB_STATE"; then
 fi
 if test -z "$HUB_ELABORATE"; then
   echo "* Setting hubctl elaborate file location"
-  HUB_ELABORATE_FILE=".hub/$HUB_DOMAIN_NAME.elaborate"
+  HUB_ELABORATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate"
   if ! $PREFER_LOCAL_STATE; then
     HUB_ELABORATE_FILE="$HUB_ELABORATE_FILE,s3://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/$STACK/hub.elaborate"
   fi

--- a/azure/configure
+++ b/azure/configure
@@ -1,13 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2086
-
-set -o pipefail
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 usage() {
   cat << EOF
@@ -17,15 +13,9 @@ Azure parameters:
   --azure-subscription          Azure Subscription (defaults to value from: AZURE_SUBSCRIPTION_ID, ARM_SUBSCRIPTION_ID)
   --dry-run                     Do not deploy cloud resources, show what will happen
   --domain-name                 Custom DNS domain name under existing base domain
-  --base-domain-resource-group  Resource Group for base domain (in case base domain
-                                    zone is located in another resource group)
-  --base-domain-subscription    Subscription for base domain (in case base domain
-                                    zone is located in another subscription)
   --prefer-local                Save deployment state locally only
 
 Bubble DNS parameters:
-  --dns-update  Request to update DNS registration
-
   New DNS record request:
     --parent-domain       Parent domain for stack (defaults to: epam.devops.delivery)
 
@@ -38,7 +28,6 @@ Bubble DNS parameters:
 EOF
 }
 
-BUBBLES_FLAGS=$* # TODO untangle Bubble DNS global vars into function args
 DRY_RUN=false
 DNS_MANAGER=bubbles
 PREFER_LOCAL_STATE=false
@@ -56,22 +45,10 @@ while [ "$1" != "" ]; do
     --domain-name )           shift
                               HUB_DOMAIN_NAME="$1"
                               ;;
-    --base-domain-resource-group ) shift
-                              HUB_BASE_DOMAIN_AZURE_RESOURCE_GROUP_NAME="$1"
-                              echo "Sorry, not implemented"
-                              exit 1
-                              ;;
-    --base-domain-subscription ) shift
-                              HUB_BASE_DOMAIN_AZURE_SUBSCRIPTION_ID="$1"
-                              echo "Sorry, not implemented"
-                              exit 1
-                              ;;
     --bubbles-secret-key )    shift
                               HUB_DOMAIN_SECRET="$1"
                               ;;
     --prefer-local )          PREFER_LOCAL_STATE=true
-                              ;;
-    --dns-update )            DNS_ACTION="update"
                               ;;
     --dry-run )               DRY_RUN=true
                               ;;
@@ -108,19 +85,18 @@ getParamFromState() {
 }
 
 getParamValueByEnvVar() {
-  param="$(params envvar "$2" | jq -cMr '.name')"
-  if test -n "$param"; then
-    getParamFromState "$1" "$param"
+  _getParamValueByEnvVar_param="$(params envvar "$2" | jq -cMr '.name')"
+  if test -n "$_getParamValueByEnvVar_param"; then
+    getParamFromState "$1" "$_getParamValueByEnvVar_param"
   fi
 }
 
 param_name() {
-  local result
-  result="$(params env "$1" | jq -r '.name | select(.)')"
-  if test -z "$result" -a -n "$2"; then
-    result="$(params json "$2" | jq -r '.name | select(.)')"
+  _param_name_result="$(params env "$1" | jq -r '.name | select(.)')"
+  if test -z "$_param_name_result" -a -n "$2"; then
+    _param_name_result="$(params json "$2" | jq -r '.name | select(.)')"
   fi
-  echo "$result"
+  echo "$_param_name_result"
 }
 
 stackname_param="$(param_name HUB_STACK_NAME dns.name)"
@@ -133,11 +109,11 @@ if test -z "$has_dnsdomain_param"; then
     # taking dns.domain from stack name
     HUB_STACK_NAME="$(params value "$stackname_param" -d "$DOT_ENV" -d "$HUB_WORKDIR/.env")"
     if test -n "$HUB_STACK_NAME"; then
-      echo -n "Using stack name: "
+      printf "Using stack name: "
       color b "$HUB_STACK_NAME"
       HUB_DOMAIN_NAME="$HUB_STACK_NAME"
     else
-      echo -n "Generating new stack name: "
+      printf "Generating new stack name: "
       new_name="$(files find-in-path bubble-dns/new-name)"
       HUB_STACK_NAME="$(eval "$new_name" | cut -d. -f1)"
       color b "$HUB_STACK_NAME"
@@ -159,11 +135,11 @@ fi
 
 if dotenv contains HUB_DOMAIN_SECRET; then
   DNS_MANAGER=bubbles
-  echo -n "* Using domain name provided by bubbles dns: ";
+  printf "* Using domain name provided by bubbles dns: ";
   color b "$HUB_DOMAIN_NAME"
 else
   DNS_MANAGER=user
-  echo -n "* Using domain name provided by user: ";
+  printf "* Using domain name provided by user: ";
   color b "$HUB_DOMAIN_NAME"
 fi
 
@@ -210,7 +186,8 @@ if test -z "$AZURE_SUBSCRIPTION_ID"; then
   exit 2
 fi
 
-echo -n "  Setting Azure subscription: "; color b "$AZURE_SUBSCRIPTION_ID"
+printf "  Setting Azure subscription: "
+color b "$AZURE_SUBSCRIPTION_ID"
 resource_group="$(params value 'azure.resourceGroup')"
 if test -z "$resource_group"; then
   resource_group_param="$(param_name AZURE_RESOURCE_GROUP_NAME)"
@@ -248,7 +225,8 @@ if test -z "$resource_group"; then
     --suggest "$suggestion" -random -empty
   AZURE_RESOURCE_GROUP_NAME=$(dotenv get AZURE_RESOURCE_GROUP_NAME)
 else
-  echo -n "  Setting Azure resource group: "; color b "$resource_group"
+  printf "  Setting Azure resource group: "
+  color b "$resource_group"
   AZURE_RESOURCE_GROUP_NAME="$resource_group"
 fi
 
@@ -287,12 +265,13 @@ fi
 if test -z "$AZURE_REGION"; then
   # https://docs.microsoft.com/en-us/cli/azure/azure-cli-configuration
   # AZURE_DEFAULTS_* automatically recognized up by `az`
-  eval $(az configure --list-defaults | jq -r '.[] | "AZURE_CONFIG_DEFAULTS_" + (.name | ascii_upcase) + "=" + .value')
+  eval "$(az configure --list-defaults | jq -r '.[] | "AZURE_CONFIG_DEFAULTS_" + (.name | ascii_upcase) + "=" + .value')"
 
   location=${AZURE_REGION:-${AZURE_DEFAULTS_LOCATION:-$AZURE_CONFIG_DEFAULTS_LOCATION}}
   if test -n "$location"; then
     echo "* Using Azure location from environment variables"
   else
+    # shellcheck disable=SC2086
     location="$(az group show $AZ_OPTS -o tsv --query 'location')"
     if test -n "$location"; then
       echo "* Using Azure location from resource group $AZURE_RESOURCE_GROUP_NAME"
@@ -315,7 +294,8 @@ if test -z "$location"; then
   exit 2
 fi
 
-echo -n "  Setting Azure location: "; color b "$location"
+printf "  Setting Azure location: "
+color b "$location"
 AZURE_REGION="$location"
 AZURE_LOCATION="$location"
 AZ_LOCATION_OPTS=""
@@ -326,13 +306,14 @@ fi
 # TODO state storage account per region?
 echo "Configuring Azure Storage Account"
 if test -z "$HUB_STATE_BUCKET"; then
-  HUB_STATE_BUCKET="hubctl$(echo $AZURE_SUBSCRIPTION_ID | cut -d- -f1)"
+  HUB_STATE_BUCKET="hubctl$(echo "$AZURE_SUBSCRIPTION_ID" | cut -d- -f1)"
 fi
 if test -z "$HUB_STATE_CONTAINER"; then
   HUB_STATE_CONTAINER=hubctl
 fi
 
-echo -n "* Checking presence of storage account $resource_group/$HUB_STATE_BUCKET: "
+printf "* Checking presence of storage account %s: " "$resource_group/$HUB_STATE_BUCKET"
+# shellcheck disable=SC2086
 if az storage account show $AZ_OPTS -n "$HUB_STATE_BUCKET" -o none 2>/dev/null; then
   echo "exist"
 else
@@ -348,7 +329,7 @@ else
     az storage account create $AZ_OPTS $AZ_STORAGE_LOCATION_OPTS --allow-blob-public-access false --sku 'Standard_ZRS' --kind 'StorageV2' -n "$HUB_STATE_BUCKET" -o none
   fi
 fi
-echo -n "* Checking presence of blob container $HUB_STATE_CONTAINER: "
+printf "* Checking presence of blob container %s: " "$HUB_STATE_CONTAINER"
 if az storage container show --account-name "$HUB_STATE_BUCKET" -n "$HUB_STATE_CONTAINER" --auth-mode login -o 'none' 2>/dev/null; then
   echo "exist"
 else
@@ -357,17 +338,20 @@ else
   else
     echo "not found"
     echo "* Deploying storage account $resource_group/$HUB_STATE_BUCKET blob container $HUB_STATE_CONTAINER..."
-    az storage container create $AZ_OPTS --account-name $HUB_STATE_BUCKET --auth-mode login --public-access off -n $HUB_STATE_CONTAINER -o none
+    # shellcheck disable=SC2086
+    az storage container create $AZ_OPTS --account-name "$HUB_STATE_BUCKET" --auth-mode login --public-access off -n "$HUB_STATE_CONTAINER" -o none
   fi
 fi
 
 if ! $DRY_RUN; then
-  HUB_STATE_REGION="$(az storage account show $AZ_OPTS -n $HUB_STATE_BUCKET -o json | jq -r .location)"
+  # shellcheck disable=SC2086
+  HUB_STATE_REGION="$(az storage account show $AZ_OPTS -n "$HUB_STATE_BUCKET" -o json | jq -r .location)"
 fi
 
 echo "Configuring Azure DNS"
-echo -n "* Checking presence of zone $HUB_DOMAIN_NAME: "
-ZONE_ID=$(az network dns zone show $AZ_OPTS -n $HUB_DOMAIN_NAME -o json 2>/dev/null | jq -r .id || true)
+printf "* Checking presence of zone %s: " "$HUB_DOMAIN_NAME"
+# shellcheck disable=SC2086
+ZONE_ID=$(az network dns zone show $AZ_OPTS -n "$HUB_DOMAIN_NAME" -o json 2>/dev/null | jq -r .id || true)
 echo "${ZONE_ID:-not found}"
 
 if $DRY_RUN; then
@@ -385,13 +369,15 @@ EOF
 elif test "$DNS_MANAGER" = "bubbles"; then
   if test -z "$ZONE_ID"; then
     echo "* Deploying zone $HUB_DOMAIN_NAME... "
+    # shellcheck disable=SC2086
     az network dns zone create $AZ_OPTS -n "$HUB_DOMAIN_NAME" -o none
     echo "Done"
   fi
 elif test "$DNS_MANAGER" = "user"; then
-  PARENT_DOMAIN="$(echo $HUB_DOMAIN_NAME | cut -d. -f2-)"
-  echo -n "* Checking presence of parent zone $PARENT_DOMAIN: "
-  PARENT_ZONE_ID=$(az network dns zone show $AZ_OPTS -n $PARENT_DOMAIN -o json 2>/dev/null | jq -r .id || true)
+  PARENT_DOMAIN="$(echo "$HUB_DOMAIN_NAME" | cut -d. -f2-)"
+  printf "* Checking presence of parent zone %s: " "$PARENT_DOMAIN"
+  # shellcheck disable=SC2086
+  PARENT_ZONE_ID=$(az network dns zone show $AZ_OPTS -n "$PARENT_DOMAIN" -o json 2>/dev/null | jq -r .id || true)
   echo "${PARENT_ZONE_ID:-not found}"
   if test -z "$ZONE_ID"; then
     if test -z "$PARENT_ZONE_ID"; then
@@ -403,11 +389,12 @@ and creating a zone "$HUB_DOMAIN_NAME" or "$PARENT_DOMAIN".
 
 Then run again:
 
-$ hubctl configure -r azure --domain-name $HUB_DOMAIN_NAME
+$ hubctl stack configure -r azure --domain-name $HUB_DOMAIN_NAME
 EOF
       exit 5
     else
       echo "* Deploying zone $HUB_DOMAIN_NAME... "
+      # shellcheck disable=SC2086
       az network dns zone create $AZ_OPTS --parent-name "$PARENT_DOMAIN" -n "$HUB_DOMAIN_NAME" -o none
       echo "Done"
       zone_just_created=1
@@ -417,9 +404,10 @@ EOF
     echo "* Updating $HUB_DOMAIN_NAME NS records in $PARENT_DOMAIN... "
     # TODO all add-record errors are suppressed for now
     # BadRequestError: Operation failed with status: 'Bad Request'. Details: The list of record sets of type 'NS' may not contain multiple entries with the same 'nsdname'
+    # shellcheck disable=SC2086
     az network dns zone show $AZ_OPTS -n $HUB_DOMAIN_NAME -o json | jq -r .nameServers[] |
       xargs -n1 \
-        az network dns record-set ns add-record $AZ_OPTS -z $PARENT_DOMAIN -n $(echo "$HUB_DOMAIN_NAME" | cut -f1 -d.) --if-none-match --ttl 300 -d 2>/dev/null || true
+        az network dns record-set ns add-record $AZ_OPTS -z "$PARENT_DOMAIN" -n "$(echo "$HUB_DOMAIN_NAME" | cut -f1 -d.)" --if-none-match --ttl 300 -d 2>/dev/null || true
     echo "Done"
   fi
   # make sure .env file is up-to-date
@@ -456,6 +444,7 @@ if test "$DNS_MANAGER" = "bubbles"; then
     echo "  - $ns"
     ns_opts="$ns_opts -ns $ns"
   done
+  # shellcheck disable=SC2086
   $bubbles_update $ns_opts
 # AK: remove this comment as curretnly misleading until we will resolve back 72 hours
 #   cat <<EOF | color green
@@ -469,7 +458,7 @@ fi
 STACK=${STACK:-$(basename "$(pwd)")}
 if test -z "$HUB_STATE"; then
   echo "* Setting hubctl state file location"
-  HUB_STATE_FILE=".hub/$HUB_DOMAIN_NAME.state"
+  HUB_STATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
   if ! $PREFER_LOCAL_STATE; then
     HUB_STATE_FILE="$HUB_STATE_FILE,az://$HUB_STATE_BUCKET/$HUB_STATE_CONTAINER/$HUB_DOMAIN_NAME/hubctl/$STACK/hub.state"
   fi
@@ -477,7 +466,7 @@ if test -z "$HUB_STATE"; then
 fi
 if test -z "$HUB_ELABORATE"; then
   echo "* Setting hubctl elaborate file location"
-  HUB_ELABORATE_FILE=".hub/$HUB_DOMAIN_NAME.elaborate"
+  HUB_ELABORATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate"
   if ! $PREFER_LOCAL_STATE; then
     HUB_ELABORATE_FILE="$HUB_ELABORATE_FILE,az://$HUB_STATE_BUCKET/$HUB_STATE_CONTAINER/$HUB_DOMAIN_NAME/hubctl/$STACK/hub.elaborate"
   fi

--- a/azure/dns/nameservers
+++ b/azure/dns/nameservers
@@ -1,13 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086
-
-set -o pipefail
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 NS_OUTPUT=text
 while [ "$1" != "" ]; do
@@ -34,7 +30,8 @@ else
   JQ_OPTS="-r .nameServers[]"
 fi
 
-if az network dns zone show $AZ_OPTS -n $HUB_DOMAIN_NAME -o json | jq $JQ_OPTS; then
+# shellcheck disable=SC2086
+if az network dns zone show $AZ_OPTS -n "$HUB_DOMAIN_NAME" -o json | jq $JQ_OPTS; then
   exit
 fi
 if test "$NS_OUTPUT" = n"json"; then

--- a/backup/after-elaborate
+++ b/backup/after-elaborate
@@ -1,14 +1,12 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 if test -L "$HUB_BACKUP_DIR/$HUB_DOMAIN_NAME/.elaborate"; then

--- a/backup/configure
+++ b/backup/configure
@@ -1,11 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 usage() {
   cat << EOF
@@ -31,10 +29,10 @@ while [ "$1" != "" ]; do
 done
 
 
-WORKDIR=${WORKDIR:-$(pwd)}
-DOT_ENV=${DOT_ENV:-"$WORKDIR/.env"}
+HUB_WORKDIR=${HUB_WORKDIR:-$(pwd)}
+DOT_ENV=${DOT_ENV:-"$HUB_WORKDIR/.env"}
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR="$WORKDIR/.hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 dotenv -f "$DOT_ENV" set "HUB_BACKUP_DIR=\"$HUB_BACKUP_DIR\""
 mkdir -p "$HUB_BACKUP_DIR"

--- a/bin/files
+++ b/bin/files
@@ -131,7 +131,7 @@ abspath() {
   else
     name="$(basename "$1")"
     dir="$(dirname "$1")"
-    if test -n "dir"; then
+    if test -n "$dir"; then
       echo "$(abspath "$dir")/$name"
     fi
   fi

--- a/bin/kubeconfig
+++ b/bin/kubeconfig
@@ -1,9 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 # shellcheck disable=SC2086,SC2064,SC2046
 
@@ -38,9 +38,7 @@ DOT_ENV=${DOT_ENV:-".env"}
 if test -z "$HUB_WORKDIR"; then
   HUB_WORKDIR=$(dotenv get "HUB_WORKDIR" --default "$(pwd)")
 fi
-# if test -z "$HUB_KUBECONFIG"; then
-#   HUB_KUBECONFIG=$(dotenv get "HUB_KUBECONFIG" --default "$USER/.kube/config")
-# fi
+
 HUB_DOMAIN_NAME="${HUB_DOMAIN_NAME:-$(dotenv get HUB_DOMAIN_NAME)}"
 KUBECONFIG="${KUBECONFIG:-"$HOME/.kube/config"}"
 KUBECONTEXT="_"
@@ -91,7 +89,7 @@ while [ "$1" != "" ]; do
 done
 
 test_cluster() {
-  echo -n "* Validating kubeconfig... "
+  printf "* Validating kubeconfig... "
   if kubectl cluster-info > /dev/null; then
     echo ok
   else
@@ -111,12 +109,6 @@ ktx_cluster_name() {
     | $jq --arg ktx "$1" '.contexts[] | select(.name == $ktx).context.cluster'
 }
 
-ktx_cluster_name() {
-  # shellcheck disable=SC2016
-  kubectl config view --raw -o json 2>/dev/null  \
-    | $jq --arg ktx "$1" '.contexts[] | select(.name == $ktx).context.cluster'
-}
-
 ktx_user_json_by_name() {
   # shellcheck disable=SC2016
   kubectl config view --raw -o json 2>/dev/null  \
@@ -124,19 +116,18 @@ ktx_user_json_by_name() {
 }
 
 ktx_cluster_json_by_name() {
-  local new_name
+  _ktx_cluster_json_by_name_new_name=
   if test -n "$2"; then
-    new_name="$2"
+    _ktx_cluster_json_by_name_new_name="$2"
   else
-    new_name="$1"
+    _ktx_cluster_json_by_name_new_name="$1"
   fi
   # shellcheck disable=SC2016
   kubectl config view --raw -o json 2>/dev/null \
-    | $jq --arg old_name "$1" --arg new_name "$new_name" '.clusters[] | select(.name == $old_name) + {"name": $new_name}'
+    | $jq --arg old_name "$1" --arg new_name "$_ktx_cluster_json_by_name_new_name" '.clusters[] | select(.name == $old_name) + {"name": $new_name}'
 }
 
 get_info() {
-  local cluster_name user_name server workdir
   case "$2" in
     kubecontext | context )
       echo "$1"
@@ -145,8 +136,8 @@ get_info() {
       ktx_cluster_name "$1"
     ;;
     server | api_server | api-server )
-      cluster_name="$(ktx_cluster_name "$1")"
-      ktx_cluster_json_by_name "$cluster_name" | $jq '.cluster.server | select(.)'
+      _get_info_cluster_name="$(ktx_cluster_name "$1")"
+      ktx_cluster_json_by_name "$_get_info_cluster_name" | $jq '.cluster.server | select(.)'
     ;;
     * )
       color e "unknown parameter: $2"
@@ -156,13 +147,12 @@ get_info() {
 }
 
 export_to_hub() {
-  local cluster_name user_name server workdir
-  cluster_name="$(ktx_cluster_name $1)"
-  workdir="$HUB_WORKDIR/.hub/kube/$cluster_name"
-  mkdir -p "$workdir"
+  _export_to_hub_cluster_name="$(ktx_cluster_name $1)"
+  _export_to_hub_workdir="$HUB_WORKDIR/.hub/kube/$_export_to_hub_cluster_name"
+  mkdir -p "$_export_to_hub_workdir"
 
-  server="$(ktx_cluster_json_by_name "$cluster_name" | $jq '.cluster.server | select(.)')"
-  user_name="$(ktx_username $1)"
+  _export_to_hub_server="$(ktx_cluster_json_by_name "$_export_to_hub_cluster_name" | $jq '.cluster.server | select(.)')"
+  _export_to_hub_user_name="$(ktx_username $1)"
 
   if test -n "$PRINT_OUTPUTS"; then
   cat << EOF
@@ -172,26 +162,26 @@ Outputs:
 EOF
   fi
 
-  echo "hub_kubernetes_api_endpoint = \"$server\""
-  ca_pem="$(ktx_cluster_json_by_name "$cluster_name" | $jq '.cluster["certificate-authority-data"] | select(.)')"
+  echo "hub_kubernetes_api_endpoint = \"$_export_to_hub_server\""
+  ca_pem="$(ktx_cluster_json_by_name "$_export_to_hub_cluster_name" | $jq '.cluster["certificate-authority-data"] | select(.)')"
   if test -n "$ca_pem"; then
-    echo "$ca_pem" > "$workdir/ca.pem"
-    echo "hub_kubernetes_ca_cert = \"file://$(files abspath "$workdir/ca.pem")\""
+    echo "$ca_pem" > "$_export_to_hub_workdir/ca.pem"
+    echo "hub_kubernetes_ca_cert = \"file://$(files abspath "$_export_to_hub_workdir/ca.pem")\""
   else
     echo "hub_kubernetes_ca_cert = \"\""
   fi
-  client_pem="$(ktx_user_json_by_name "$user_name" | $jq '.user["client-certificate-data"] | select(.)')"
+  client_pem="$(ktx_user_json_by_name "$_export_to_hub_user_name" | $jq '.user["client-certificate-data"] | select(.)')"
   if test -n "$client_pem"; then
-    echo "$client_pem" > "$workdir/client.pem"
-    echo "hub_kubernetes_client_cert = \"file://$(files abspath "$workdir/client.pem")\""
+    echo "$client_pem" > "$_export_to_hub_workdir/client.pem"
+    echo "hub_kubernetes_client_cert = \"file://$(files abspath "$_export_to_hub_workdir/client.pem")\""
   else
     echo "hub_kubernetes_client_cert = \"\""
   fi
 
-  client_pem="$(ktx_user_json_by_name "$user_name" | $jq '.user["client-key-data"] | select(.)')"
+  client_pem="$(ktx_user_json_by_name "$_export_to_hub_user_name" | $jq '.user["client-key-data"] | select(.)')"
   if test -n "$client_pem"; then
-    echo "$client_pem" > "$workdir/client.pem"
-    echo "hub_kubernetes_client_key = \"file://$(files abspath "$workdir/client.pem")\""
+    echo "$client_pem" > "$_export_to_hub_workdir/client.pem"
+    echo "hub_kubernetes_client_key = \"file://$(files abspath "$_export_to_hub_workdir/client.pem")\""
   else
     echo "hub_kubernetes_client_key = \"\""
   fi
@@ -204,37 +194,39 @@ EOF
 
 extract_kubecontext() {
   # Should we test before extract?
-  local cluster_name user_name new_ktx_name
+  _extract_kubecontext_cluster_name=
+  _extract_kubecontext_user_name=
+  _extract_kubecontext_new_ktx_name=
   if test -n "$2"; then
-    new_ktx_name="$2"
+    _extract_kubecontext_new_ktx_name="$2"
   else
-    new_ktx_name="$1"
+    _extract_kubecontext_new_ktx_name="$1"
   fi
 
-  cluster_name="$(ktx_cluster_name $1)"
-  user_name="$(ktx_username $1)"
-  if test -n "$cluster_name" -a -n "$user_name"; then
+  _extract_kubecontext_cluster_name="$(ktx_cluster_name $1)"
+  _extract_kubecontext_user_name="$(ktx_username $1)"
+  if test -n "$_extract_kubecontext_cluster_name" -a -n "$_extract_kubecontext_user_name"; then
     cat <<EOF | $jq > $OUTPUT
 {
   "kind": "Config",
   "apiVersion": "v1",
   "preferences": {},
   "clusters": [
-    $(ktx_cluster_json_by_name $cluster_name)
+    $(ktx_cluster_json_by_name $_extract_kubecontext_cluster_name)
   ],
   "users": [
-    $(ktx_user_json_by_name $user_name)
+    $(ktx_user_json_by_name $_extract_kubecontext_user_name)
   ],
   "contexts": [
     {
       "name": "$2",
       "context": {
-        "cluster": "$cluster_name",
-        "user": "$user_name"
+        "cluster": "$_extract_kubecontext_cluster_name",
+        "user": "$_extract_kubecontext_user_name"
       }
     }
   ],
-  "current-context": "$new_ktx_name"
+  "current-context": "$_extract_kubecontext_new_ktx_name"
 }
 EOF
   else

--- a/env/configure
+++ b/env/configure
@@ -1,11 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2086,SC2034
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 usage() {
   cat << EOF
@@ -20,15 +18,15 @@ ident() {
 }
 
 if test -n "$(which tty)" && tty -s || echo "$-" | grep 'i'; then
-  INTERACTIVE=true
+  HUB_INTERACTIVE="1"
 else
-  INTERACTIVE=false
+  HUB_INTERACTIVE="0"
 fi
 
 while [ "$1" != "" ]; do
   case $1 in
     --defaults )
-      INTERACTIVE=false
+      HUB_INTERACTIVE="0"
       ;;
     --output )
       shift
@@ -46,9 +44,11 @@ while [ "$1" != "" ]; do
   shift
 done
 
+export HUB_INTERACTIVE
+
 if test -z "$HUB_WORKDIR"; then
   FIRST_FILE="$(echo "$HUB_FILES" | awk '{print $1;}')"
-  if test -f $FIRST_FILE; then
+  if test -f "$FIRST_FILE"; then
     HUB_WORKDIR="$(dirname "$FIRST_FILE")"
   else
     HUB_WORKDIR="$(pwd)"
@@ -56,7 +56,7 @@ if test -z "$HUB_WORKDIR"; then
   export HUB_WORKDIR
 fi
 
-if test $VERBOSE = "true"; then
+if test "$VERBOSE" = "true"; then
   set -x
 fi
 
@@ -70,5 +70,5 @@ fi
 for e in $(params listenv); do
   pname="$(params "$e" envvar | jq -cMr '.name? | select(.)')"
   pcomponent="$(params "$e" envvar | jq -cMr '.component? | select(.)')"
-  ask env "$e" -m "parameter $pname $pcomponent" +empty -d "$DOT_ENV" -d "$(files abspath ".env")" -ask-env
+  ask env "$e" -m "parameter $pname $pcomponent" +empty -d "$DOT_ENV" -d "$(files abspath "$HUB_WORKDIR/.env")" -ask-env
 done

--- a/gcp/clouddns/nameservers
+++ b/gcp/clouddns/nameservers
@@ -1,16 +1,11 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
-# shellcheck disable=SC2086
-
-set -o pipefail
-
-JQ_ARGS="-cMr"
-jq="jq $JQ_ARGS"
+jq="jq -cMr"
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -31,7 +26,7 @@ fi
 ZONE_NAME=$(gcloud dns managed-zones list --filter=dnsName:"$HUB_DOMAIN_NAME" \
   --format json | $jq '.[].name' | xargs)
 
-if gcloud dns managed-zones describe "$ZONE_NAME"\
+if gcloud dns managed-zones describe "$ZONE_NAME" \
     --format json | $jq '.nameServers|select(.)[]'; then
   exit
 fi

--- a/gcp/configure
+++ b/gcp/configure
@@ -1,11 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2090
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 usage() {
     cat <<EOF
@@ -26,8 +24,6 @@ check_api_enabled() {
 }
 
 jq='jq -cM'
-# shellcheck disable=SC2089
-# curl='curl -isH "Metadata-Flavor: Google"'
 dotenv="dotenv -f $DOT_ENV"
 DNSSEC_STATE="on"
 while [ "$1" != "" ]; do
@@ -39,9 +35,6 @@ while [ "$1" != "" ]; do
     --gcp-project-id)
         shift
         GOOGLE_PROJECT="$1"
-        ;;
-    --force)
-        FORCE_FUNCTION_UPDATE=1
         ;;
     --domain-name)
         shift
@@ -62,17 +55,16 @@ fi
 HUB_CLOUD_PROVIDER="gcp"
 export HUB_CLOUD_PROVIDER
 
-echo -n "Setting current GCP project to: "
+printf "Setting current GCP project to: "
 color b "$GOOGLE_PROJECT"
 echo "* $(gcloud config set project "$GOOGLE_PROJECT" -q 2>&1)"
 
-# shellcheck disable=SC1091
 if test -z "$(params env HUB_DOMAIN_NAME)"; then
   stack_name_param=$(params env "HUB_STACK_NAME" | jq -cMr '.name | select(.)')
   if test -n "$stack_name_param"; then
     HUB_STACK_NAME="$(params value "$stack_name_param" -d "$DOT_ENV" -d "$HUB_WORKDIR/.env")"
     if test -z "$HUB_STACK_NAME"; then
-      echo -n "Generating new stack name: "
+      printf "Generating new stack name: "
       new_name="$(files find-in-path bubble-dns/new-name)"
       HUB_STACK_NAME="$(eval "$new_name" | cut -d. -f1)"
       color b "$HUB_STACK_NAME"
@@ -84,7 +76,7 @@ if test -z "$(params env HUB_DOMAIN_NAME)"; then
     fromEnv: HUB_DOMAIN_NAME
 EOF
     else
-      echo -n "Using stack name: "
+      printf "Using stack name: "
       color b "$HUB_STACK_NAME"
       HUB_DOMAIN_NAME="$HUB_STACK_NAME"
     fi
@@ -106,16 +98,16 @@ else
   if test -z "$HUB_DOMAIN_NAME"; then
     echo "* Requesting new DNS name"
     # shellcheck disable=SC1090
-    source "$(dirname "$0")/../bubble-dns/include"
+    . "$(files -e find-in-path bubble-dns/include)"
     configureBubbleDNS
   fi
-  echo -n "* Enabling API for dns.googleapis.com... "
+  printf "* Enabling API for dns.googleapis.com... "
   gcloud services enable "dns.googleapis.com" && echo "done"
-  echo -n "* Cloud DNS Zone "
+  printf "* Cloud DNS Zone "
   color -n b "$HUB_DOMAIN_NAME... "
   FOUND=$(gcloud dns managed-zones list --filter=dnsName:"$HUB_DOMAIN_NAME" \
     --format json | $jq '. | length' | xargs)
-  if test "$FOUND" == "0"; then
+  if test "$FOUND" = "0"; then
     echo "not found"
     echo "  Creating (takes a minute)... "
     gcloud dns managed-zones create "$(echo "$HUB_DOMAIN_NAME" | cut -d. -f1)" \
@@ -146,12 +138,12 @@ fi
 if test -z "$HUB_STATE_BUCKET"; then
   HUB_STATE_BUCKET="superhub-$GOOGLE_PROJECT"
 fi
-echo -n "Configuring state storage: "
+printf "Configuring state storage: "
 color b "gs://$HUB_STATE_BUCKET"
 if gsutil -q ls -b "gs://$HUB_STATE_BUCKET" > /dev/null 2>&1; then
   echo "* Bucket gs://$HUB_STATE_BUCKET already exist in $GOOGLE_PROJECT"
 else
-  echo -n "* Creating bucket gs://$HUB_STATE_BUCKET... "
+  printf "* Creating bucket gs://%s... " "$HUB_STATE_BUCKET"
 	if gsutil mb -c standard -b on "gs://$HUB_STATE_BUCKET" > /dev/null 2>&1; then
 		echo "done"
 	else
@@ -161,8 +153,8 @@ else
 fi
 gsutil label ch -l "managed-by":"hubctl" "gs://$HUB_STATE_BUCKET" > /dev/null 2>&1
 
-HUB_STATE_FILE="$(files abspath ".hub/$HUB_DOMAIN_NAME.state"),gs://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/hub.state"
-HUB_ELABORATE_FILE="$(files abspath ".hub/$HUB_DOMAIN_NAME.elaborate"),gs://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/hub.elaborate"
+HUB_STATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state,gs://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/hub.state"
+HUB_ELABORATE_FILE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate,gs://$HUB_STATE_BUCKET/$HUB_DOMAIN_NAME/hub/hub.elaborate"
 
 $dotenv contains 'HUB_CLOUD_PROVIDER'   || $dotenv set 'HUB_CLOUD_PROVIDER' "$HUB_CLOUD_PROVIDER"
 $dotenv contains 'HUB_STATE_BUCKET'     || $dotenv set 'HUB_STATE_BUCKET' "$HUB_STATE_BUCKET"
@@ -175,8 +167,10 @@ $dotenv contains 'HUB_ELABORATE'        || $dotenv set 'HUB_ELABORATE' "$HUB_ELA
 $dotenv contains 'HUB_TOOLBOX_IMAGE'    || $dotenv set 'HUB_TOOLBOX_IMAGE' 'ghcr.io/epam/hub-toolbox:gcp'
 
 if test -n "$CLOUD_SHELL"; then
-  echo "* Hubctl runs inside a Cloud Shell environment"
-  echo "  Setting deploy profile to: local"
+  cat << EOF
+* Hubctl runs inside a Cloud Shell environment
+  Setting deploy profile to: local
+EOF
   $dotenv set "HUB_DEPLOY_PROFILE" "local"
 fi
 if test -z "$HUB_STACK_NAME" -a -n "$HUB_DOMAIN_NAME"; then

--- a/gcp/init
+++ b/gcp/init
@@ -1,9 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 usage() {
@@ -17,18 +17,18 @@ EOF
 }
 
 contains() {
-  local pattern result
-  pattern="$1"
+  _contains_pattern="$1"
+  _contains_result=
   shift
 
   # shellcheck disable=SC2048
   for w in $*; do
-    if test "$w" = "$pattern"; then
-      result="$w"
+    if test "$w" = "$_contains_pattern"; then
+      _contains_result="$w"
       break
     fi
   done
-  test -n "$result"
+  test -n "$_contains_result"
 }
 
 ident() {
@@ -61,9 +61,10 @@ while [ "$1" != "" ]; do
   shift
 done
 
-# if test "$VERBOSE" = "true"; then
-#   set -x
-# fi
+VERBOSE=${VERBOSE:-"false"}
+if test "$VERBOSE" = "true"; then
+  set -x
+fi
 dotenv="dotenv -f $DOT_ENV"
 # shellcheck disable=SC2089
 curl="curl -isH 'Metadata-Flavor: Google'"

--- a/hub-component-download
+++ b/hub-component-download
@@ -1,10 +1,15 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
+HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
+HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
+PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
+export PATH
 
 usage() {
   cat << EOF
@@ -13,10 +18,10 @@ Helper tool that dowloads components specified in hub.yaml
 Use flags "-A" or "-C" to download all components or subset of them
 
 Usage:
-$ $(basename "$0") -A -F
+$ $HUB_EXTENSION -A -F
 To download all components and overwrite if they already exist
 
-$ $(basename "$0") -F -C minio,tiller
+$ $HUB_EXTENSION -F -C minio,tiller
 To download specified componenets and overwrite if they already exist
 
 
@@ -33,70 +38,75 @@ EOF
 
 # shellcheck disable=SC2086
 local_dir() {
-  local f res
-  for f in $HUB_FILES; do
-    res=$(
-      yq e -o=json "$f" | \
+  _local_dir_f=
+  _local_dir_res=
+  for _local_dir_f in $HUB_FILES; do
+    _local_dir_res=$(
+      yq e -o=json "$_local_dir_f" | \
       jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.dir'
     )
-    test -z "$res" || break
+    test -z "$_local_dir_res" || break
   done
-  echo "$res"
+  echo "$_local_dir_res"
 }
 
 # shellcheck disable=SC2086
 git_sub_dir() {
-    local f res
-    for f in $HUB_FILES; do
-      res=$(
-        yq e -o=json "$f" | \
-        jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.git.subDir|select(.)'
-      )
-      test -z "$res" || break
-    done
-    echo "$res"
+  _git_sub_dir_f=
+  _git_sub_dir_res=
+  for _git_sub_dir_f in $HUB_FILES; do
+    _git_sub_dir_res=$(
+      yq e -o=json "$_git_sub_dir_f" | \
+      jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.git.subDir|select(.)'
+    )
+    test -z "$_git_sub_dir_res" || break
+  done
+  echo "$_git_sub_dir_res"
 }
 
 # shellcheck disable=SC2086
 git_remote() {
-  local f res
-  for f in $HUB_FILES; do
-    res=$(
-      yq e -o=json "$f" | \
+  _git_remote_f=
+  _git_remote_res=
+  for _git_remote_f in $HUB_FILES; do
+    _git_remote_res=$(
+      yq e -o=json "$_git_remote_f" | \
       jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.git.remote|select(.)'
     )
-    test -z "$res" || break
+    test -z "$_git_remote_res" || break
   done
-  echo "$res"
+  echo "$_git_remote_res"
 }
 
 # shellcheck disable=SC2086
 git_cloned_dir() {
-  local f res
-  for f in $HUB_FILES; do
-    res=$(
-      yq e -o=json "$f" | \
+  _git_cloned_dir_f=
+  _git_cloned_dir_res=
+  for _git_cloned_dir_f in $HUB_FILES; do
+    _git_cloned_dir_res=$(
+      yq e -o=json "$_git_cloned_dir_f" | \
       jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.git.remote|select(.)|split("/")[-1] |split(".")[0]'
     )
-    test -z "$res" || break
+    test -z "$_git_cloned_dir_res" || break
   done
-  echo "$res"
+  echo "$_git_cloned_dir_res"
 }
 
 # shellcheck disable=SC2086
 git_ref() {
-  local f res
-  for f in $HUB_FILES; do
-    res=$(
-      yq e -o=json "$f" | \
+  _git_ref_f=
+  _git_ref_res=
+  for _git_ref_f in $HUB_FILES; do
+    _git_ref_res=$(
+      yq e -o=json "$_git_ref_f" | \
       jq -r '.components?|select(.)[]|select(.name=="'$1'")|.source.git.ref|select(.)'
     )
-    if test -n "$res"; then
-      echo "$res"
+    if test -n "$_git_ref_res"; then
+      echo "$_git_ref_res"
       break;
     fi
   done
-  if test -z "$res"; then
+  if test -z "$_git_ref_res"; then
     echo "main"
   fi
 }
@@ -106,15 +116,14 @@ if test -z "$*"; then
   exit 1
 fi
 
-if test -f ".env"; then
-  set +a
-  eval "$(dotenv export -f ".env" )"
-  set -a
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
 fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 CHECK=${CHECK:-true}
 COMPONENT_JSON_PATH=${COMPONENT_JSON_PATH:-.hub/component_rev.json}
-WORKDIR=${WORKDIR:-$(pwd)}
 while [ "$1" != "" ]; do
     case $1 in
     -f | --file)        shift
@@ -143,7 +152,7 @@ while [ "$1" != "" ]; do
 done
 
 if test -z "$HUB_FILES"; then
-  echo "Error: cannot find hubctl files. Please run this command with --file flag"
+  color error "Error: cannot find hubctl files. Please run this command with --file flag"
   exit 1
 fi
 
@@ -154,14 +163,15 @@ if test -z "$COMPONENTS"; then
     # GIT_URLS=$(yq e -o=json hub.yaml | jq -r '.components[].source.git.remote | select(length > 0)'  | sort | uniq)
   done
   if test -z "$COMPONENTS"; then
-    echo "Error: cannot find components in [$HUB_FILES]"
+    color error "Error: cannot find components in [$HUB_FILES]"
+    exit 2
   fi
 fi
 
 TEMP_DIR=$(mktemp -d)
 trap 'rm -rf $TEMP_DIR' EXIT
 for component in $COMPONENTS; do
-  echo -n "* Checking component $component: "
+  printf "* Checking component %s: " "$component"
   to_dir=$(local_dir "$component")
   if test -d "$to_dir"; then
     echo "already exists"
@@ -174,13 +184,13 @@ for component in $COMPONENTS; do
 
   temp="$TEMP_DIR/$(echo "$remote+$ref" | sed 's/[^0-9a-zA-Z-]*//g')"
   if test ! -d "$temp"; then
-    echo -n "  Cloning remote $remote ($ref): "
+    printf "  Cloning remote %s (%s): " "$remote" "$ref"
     git clone "$remote" "$temp" > /dev/null 2>&1
     git -C "$temp" checkout "$ref" > /dev/null 2>&1
     echo "done"
   fi
-  echo -n "  Store to $to_dir: "
-  mkdir -p "$(dirname $WORKDIR/$to_dir)"
-  cp -rf "$temp/$sub_dir" "$WORKDIR/$to_dir"
+  printf "  Store to %s: " "$to_dir"
+  mkdir -p "$(dirname "$HUB_WORKDIR/$to_dir")"
+  cp -rf "$temp/$sub_dir" "$HUB_WORKDIR/$to_dir"
   echo "Done"
 done

--- a/hub-configure
+++ b/hub-configure
@@ -1,11 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2046,SC2068,SC2064,SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
@@ -21,7 +19,7 @@ usage() {
   cat << EOF
 Reads configuration information in ${HUB_FILES:-hub.yaml} and configures stack for deployment.
 
-The result of configuration is saved under ".hub/env/" with a symlink ".env" pointing
+The result of configuration is saved under "$HUB_WORKDIR/.hub/env/" with a symlink "$HUB_WORKDIR/.env" pointing
 to the current configuration.
 
 Usage:
@@ -42,22 +40,23 @@ EOF
     if echo "$2" | grep -oh "\w*$req\w*"; then
       continue
     fi
-    local configure
+    _usage_configure=
     if test -f "$HUB_WORKDIR/.hub/$req/configure"; then
-      configure="$HUB_WORKDIR/.hub/$req/configure"
+      _usage_configure="$HUB_WORKDIR/.hub/$req/configure"
     elif test -f "$HUB_HOME/$req/configure"; then
-      configure=$HUB_HOME/$req/configure
+      _usage_configure=$HUB_HOME/$req/configure
     else
       continue
     fi
-    $configure --help
+    $_usage_configure --help
   done
 }
 
 real_files() {
+  # shellcheck disable=SC2068
   for f in $@; do
     if test -f "$f"; then
-      echo -n " $f"
+      printf " %s" "$f"
     fi
   done
   echo
@@ -69,8 +68,27 @@ HELP=false
 ARGS=$*
 HUB_FILES=""
 
-if test -f ".env"; then
-  eval $(dotenv export -f ".env" )
+if test -f "$HUB_WORKDIR/.env"; then
+  echo "Environment file: exist"
+  if test -L "$HUB_WORKDIR/.env"; then
+    DOT_ENV="$(readlink -n "$HUB_WORKDIR/.env")"
+  else
+    DOT_ENV="$HUB_WORKDIR/.env"
+  fi
+  export DOT_ENV
+  # shellcheck disable=SC2046
+  eval $(dotenv export -f "$HUB_WORKDIR/.env")
+  if test -n "$HUB_CLOUD_PROVIDER"; then
+    echo "* Cloud provider: $HUB_CLOUD_PROVIDER";
+  fi
+else
+  cat << EOF | color e
+Error: cannot find .env file
+
+Did you run?
+  hubctl stack init
+EOF
+  exit 1
 fi
 
 while [ "$1" != "" ]; do
@@ -92,10 +110,6 @@ EOF
       shift
       REQS=$(echo "$REQS $1" | xargs)
       ;;
-    # -i | --init-dotenv )
-    #   shift
-    #   INIT_DOTENV="$1"
-    #   ;;
     -S | --silent )
       SILENT=true
       ;;
@@ -114,53 +128,53 @@ if $VERBOSE; then
   set -x
 fi
 
-# if test -n "$INIT_DOTENV" -a ! -f "$INIT_DOTENV"; then
-#   echo "Error: init dotenv $INIT_DOTENV file not found"
-#   exit 1
-# fi
-
 TEMP_FILES=""
 temp_file(){
-  local temp
-  temp=$(mktemp) || exit 1
-  TEMP_FILES="$TEMP_FILES $temp"
-  echo $temp
+  _temp_file_temp=
+  _temp_file_temp=$(mktemp) || exit 1
+  TEMP_FILES="$TEMP_FILES $_temp_file_temp"
+  echo "$_temp_file_temp"
 }
 
 update_symlink() {
+  # shellcheck disable=SC2046
   if test -L "$2" && test $(readlink -n "$2") != "$1"; then
     unlink "$2"
   fi
   if test ! -f "$2"; then
     ln -sf "$1" "$2"
-    echo "* Updated .env link to $(basename $1)"
+    echo "* Updated .env link to $(basename "$1")"
   fi
 }
 
 finalize() {
   # shellcheck disable=SC2046
-  local rv=$?
-  local profiles
-  if test "$rv" != "0"; then
+  _finalize_rv=$?
+  _finalize_profiles=
+  if test "$_finalize_rv" != "0"; then
     cat << EOF | color e
 See error above!
 
 Configuration has been reverted!
 EOF
-    exit $rv
+    exit $_finalize_rv
   fi
-  if test -d "$HUB_WORKDIR/.hub/profiles"; then profiles="$profiles $(ls "$HUB_WORKDIR/.hub/profiles")"; fi
-  if test -d "$HUB_HOME/profiles"; then profiles="$profiles $(ls $HUB_HOME/profiles)"; fi
+  if test -d "$HUB_WORKDIR/.hub/profiles"; then
+    _finalize_profiles="$_finalize_profiles $(ls "$HUB_WORKDIR/.hub/profiles")";
+  fi
+  if test -d "$HUB_HOME/profiles"; then
+    _finalize_profiles="$_finalize_profiles $(ls "$HUB_HOME/profiles")";
+  fi
   HUB_DOMAIN_NAME=$(dotenv get "HUB_DOMAIN_NAME" --default "$HUB_DOMAIN_NAME")
   HUB_STACK_NAME=$(dotenv get "HUB_STACK_NAME" --default "$HUB_STACK_NAME")
   if test -n "$HUB_DOMAIN_NAME"; then
-    dotenv_file="$(files abspath .hub/env/$HUB_DOMAIN_NAME.env)"
+    dotenv_file="$(files abspath "$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.env")"
   elif test -n "$HUB_STACK_NAME"; then
-    dotenv_file="$(files abspath .hub/env/$HUB_STACK_NAME.env)"
+    dotenv_file="$(files abspath "$HUB_WORKDIR/.hub/env/$HUB_STACK_NAME.env")"
   else
-    dotenv_file="$(files abspath .hub/env/.env)"
+    dotenv_file="$(files abspath "$HUB_WORKDIR/.hub/env/.env")"
   fi
-  if test "$(files abspath $DOT_ENV)" != "$dotenv_file"; then
+  if test "$(files abspath "$DOT_ENV")" != "$dotenv_file"; then
     echo "Saving configuration as: $(basename "$dotenv_file")"
     if files copy "$DOT_ENV" "$dotenv_file" | ident; then
       echo "* Removing old: $DOT_ENV"
@@ -184,14 +198,14 @@ EOF
 
 if test -z "$HUB_WORKDIR"; then
   FIRST_FILE="$(echo "$HUB_FILES" | awk '{print $1;}')"
-  if test -f $FIRST_FILE; then
+  if test -f "$FIRST_FILE"; then
     HUB_WORKDIR=$(dirname "$FIRST_FILE")
   else
     HUB_WORKDIR=$(pwd)
   fi
 fi
 
-if test ! -d $HUB_WORKDIR; then
+if test ! -d "$HUB_WORKDIR"; then
   mkdir -p "$HUB_WORKDIR"
 fi
 
@@ -217,6 +231,7 @@ WORKDIR="$HUB_WORKDIR"
 # will be used by exact extensions
 export WORKDIR SILENT VERBOSE HUB_FILES HUB_HOME KUBECONFIG HUB_WORKDIR
 if test -z "$REQS"; then
+  # shellcheck disable=SC2086
   REQS="$(yq e '' $HUB_FILES -o json | jq -cMr 'select(.extensions).extensions | select(.configure).configure[]')"
 fi
 
@@ -225,31 +240,10 @@ if $HELP; then
   exit
 fi
 
+# shellcheck disable=SC2086
 HUB_FILES="$(real_files $HUB_FILES)"
 export HUB_FILES
 trap 'finalize $?' EXIT
-
-if test -f "$HUB_WORKDIR/.env"; then
-  echo "Environment file: exist"
-  if test -L "$HUB_WORKDIR/.env"; then
-    DOT_ENV="$(readlink -n "$HUB_WORKDIR/.env")"
-  else
-    DOT_ENV="$HUB_WORKDIR/.env"
-  fi
-  export DOT_ENV
-  eval $(dotenv export -f "$HUB_WORKDIR/.env")
-  if test -n "$HUB_CLOUD_PROVIDER"; then
-    echo "* Cloud provider: $HUB_CLOUD_PROVIDER";
-  fi
-else
-  cat << EOF | color e
-Error: cannot find .env file
-
-Did you run?
-  hubctl stack init
-EOF
-  exit 1
-fi
 
 for req in $(echo "$REQS" | xargs -n1); do
   if test -x "$HUB_WORKDIR/$req"; then
@@ -262,9 +256,11 @@ for req in $(echo "$REQS" | xargs -n1); do
     continue
   fi
 
-  echo -n "Running configuration for: "
+  printf "Running configuration for: "
   color b "$req"
+  # shellcheck disable=SC2086
   if $configure --output "$DOT_ENV" $ARGS; then
+    # shellcheck disable=SC2046
     eval $(dotenv export -f "$DOT_ENV")
   else
     cat << EOF | color e
@@ -289,6 +285,7 @@ if ! dotenv contains "HUB_DEPLOY_PROFILE"; then
 
   # We don't want run pod if inside of the pod
   if test ! -f "/var/run/secrets/kubernetes.io/serviceaccount/token"; then
+      # shellcheck disable=SC2086
       r="$(yq e '' $HUB_FILES -o=json | jq -cMr --arg a "kubernetes" '.requires|select(.)[]|select(.==$a)')"
       if test -n "$r"; then
         HUB_DEPLOY_PROFILE="kubernetes"
@@ -314,10 +311,10 @@ dotenv set "HUB_FILES" "$HUB_FILES"
 
 if ! dotenv contains "HUB_STATE"; then
   echo "* Setting hubctl state to local file"
-  dotenv set "HUB_STATE" "$(files abspath ".hub/$HUB_DOMAIN_NAME.state")"
+  dotenv set "HUB_STATE" "$(files abspath "$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state")"
 fi
 
 if ! dotenv contains "HUB_ELABORATE"; then
   echo "* Setting hubctl elaborate to local file"
-  dotenv set  "HUB_ELABORATE" "$(files abspath ".hub/$HUB_DOMAIN_NAME.elaborate")"
+  dotenv set  "HUB_ELABORATE" "$(files abspath "$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate")"
 fi

--- a/hub-show
+++ b/hub-show
@@ -1,11 +1,14 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/
 
-# shellcheck disable=SC2086
+VERBOSE=${VERBOSE:-"false"}
+if test "$VERBOSE" = "true"; then
+  set -x
+fi
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
@@ -44,7 +47,6 @@ EOF
 
 FORMAT="${FORMAT:-yaml}"
 JQ_ARGS="${JQ_ARGS:- -Sr}"
-eval "$(dotenv -f $HUB_WORKDIR/.env export)"
 
 if ! test -t 0; then
     HUB_DOMAIN_NAME=$(< /dev/stdin xargs | cut -d " " -f1 | tr -d '"')
@@ -98,10 +100,11 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if test ! -f .env; then
-  color error "Error: cannot find .env file"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 HUB_STATE="$(dotenv get HUB_STATE --default "$HUB_STATE")"
 if test -z "$HUB_STATE"; then
@@ -116,10 +119,11 @@ if test -z "$HUB_TOKEN"; then
       HUB_FILES="$(dotenv get HUB_FILES)"
     fi
 
+    # shellcheck disable=SC2086
     has_inventory_configmap="$(yq -N e '[ .extensions.deploy.after ] | select(. == "inventory-configmap")' $HUB_FILES)"
     if test -n "$has_inventory_configmap"; then
       if test -z "$KUBECONFIG" -a -n "$HUB_KUBECONFIG" -a -e "$HUB_KUBECONFIG"; then
-        export KUBECONFIG=$HUB_KUBECONFIG
+        export KUBECONFIG="$HUB_KUBECONFIG"
       fi
       ns="kube-system"
       cm="superhub"
@@ -146,6 +150,7 @@ if test -z "$HUB_TOKEN"; then
     fi
   fi
 else
+  # shellcheck disable=SC2086
   RESP=$($hubctl api instance get -j \
       | jq -S '. | if type=="array" then . else [.] end' \
       | jq -cMr '.[] | select(.domain=="'$HUB_DOMAIN_NAME'")')
@@ -161,6 +166,7 @@ if test ! -z "$RAW_OUTPUT"; then
   if test "$FORMAT" = "yaml"; then
     echo "$RESP" | yq e -P 1>&2
   else
+    # shellcheck disable=SC2086
     echo "$RESP" | jq $JQ_ARGS . 1>&2
   fi
   exit 0
@@ -175,17 +181,22 @@ to_obj() {
 
 if test -n "$HUB_COMPONENT"; then
     if test -z "$HUB_TOKEN"; then
+      # shellcheck disable=SC2086
       if test "$(echo "$RESP" | jq -cMr '[.components|to_entries[] | .key] | index("'$HUB_COMPONENT'")')" == "null"; then
         echo "Cannot find \"$HUB_COMPONENT\" in components: $(echo "$RESP" | jq -cMr '[.components|to_entries[] | .key]') of \"$HUB_DOMAIN_NAME\"" 1>&2
         exit 3
       fi
+      # shellcheck disable=SC2086
       OUTPUTS=$(echo "$RESP" | jq -cMr '.components|to_entries[] | select(.key == "'$HUB_COMPONENT'").value | select(.outputs != null).outputs')
+      # shellcheck disable=SC2086
       PARAMETERS=$(echo "$RESP" | jq -cMr '.components|to_entries[] | select(.key == "'$HUB_COMPONENT'").value | select(.parameters != null).parameters')
     else
+      # shellcheck disable=SC2086
       if test "$(echo "$RESP" | jq -cMr '.componentsEnabled | index("'$HUB_COMPONENT'")')" == "null"; then
         echo "Cannot find \"$HUB_COMPONENT\" in components: $(echo "$RESP" | jq -cMr '.componentsEnabled') of \"$HUB_DOMAIN_NAME\"" 1>&2
         exit 3
       fi
+      # shellcheck disable=SC2086
       OUTPUTS=$(echo "$RESP" | jq -cMr '.status.components[] | select(.name == "'$HUB_COMPONENT'").outputs[] | {(.name):.value}')
       PARAMETERS=$(echo "$RESP" | jq -cMr 'select(.parameters).parameters[] | {(.name):.value}')
     fi
@@ -219,9 +230,9 @@ else
     DOCEXT="$DOCEXT $(echo "$OUTPUTS" | jq -cM '{"parameters": .}')"
 fi
 if test -z "$HUB_TOKEN"; then
-  if test -n "$(echo $RESP | jq -crM '.components|select(.)')"; then
+  if test -n "$(echo "$RESP" | jq -crM '.components|select(.)')"; then
     if test -z "$HUB_COMPONENT"; then
-      DOCBASE=$(echo $RESP | jq -crM '{
+      DOCBASE=$(echo "$RESP" | jq -crM '{
         "meta" : {
           "kind": .meta.kind | select("."),
           "name": .meta.name | select("."),
@@ -233,7 +244,7 @@ if test -z "$HUB_TOKEN"; then
         }
       }')
     else
-      DOCBASE=$(echo $RESP | jq --arg c "$HUB_COMPONENT" -crM '{
+      DOCBASE=$(echo "$RESP" | jq --arg c "$HUB_COMPONENT" -crM '{
         "meta" : {
           "kind": "component",
           "name": $c,
@@ -246,14 +257,14 @@ if test -z "$HUB_TOKEN"; then
     fi
   else
     # derive components from "provides"
-    DOCBASE=$(echo $RESP | jq -crM '{
+    DOCBASE=$(echo "$RESP" | jq -crM '{
       "components" : [.provides|to_entries[].value|select(.)[]] | unique,
       "provides" : [select(.provides != null).provides|to_entries[]|.key],
       "status" : ""
     }')
   fi
 else
-  DOCBASE=$(echo $RESP | jq -crM '{
+  DOCBASE=$(echo "$RESP" | jq -crM '{
       "environment": .environment.name,
       "provides": [.provides|to_entries[]|.key],
       "components": .componentsEnabled,
@@ -264,12 +275,12 @@ else
 fi
 
 if test "$FORMAT" = "yaml"; then
-    # shellcheck disable=SC2090
+    # shellcheck disable=SC2090,SC2086
     echo "$DOCBASE" "$DOCEXT" | jq -cMs 'reduce .[] as $item ({}; . * $item) ' \
     | jq $JQ_ARGS \
     | yq e -P 'del(.. | select((tag == "!!map" and length == 0) or (tag == "!!seq" and length == 0) or (. == null)))' -
 else
-    # shellcheck disable=SC2090
+    # shellcheck disable=SC2090,SC2086
     echo "$DOCBASE" "$DOCEXT" | jq -cMs 'reduce .[] as $item ({}; . * $item) ' \
     | jq $JQ_ARGS
 fi

--- a/hub-stack
+++ b/hub-stack
@@ -1,9 +1,9 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 usage() {

--- a/hub-stack-backup
+++ b/hub-stack-backup
@@ -1,9 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 usage() {

--- a/hub-stack-backup-create
+++ b/hub-stack-backup-create
@@ -1,14 +1,12 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
-# shellcheck disable=SC2086
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -22,6 +20,10 @@ if test -z "$hubctl"; then
   color error "hubctl not found in PATH. Please install hubctl first."
   exit 1
 fi
+
+is_url() {
+  echo "$1" | grep -e '^https\?://' >/dev/null 2>&1
+}
 
 usage() {
 cat << EOF
@@ -41,22 +43,19 @@ Parameters:
     -t --tag              Backup tags
     -c --component        Components to backup
     -V  --verbose         Verbose outputs for debug purpose
-    --tty                 Use TTY (terminal) mode for hubctl ${verb}
-    --no-tty              Do not use TTY (terminal) mode for hubctl ${verb}
-    --                    Separator to define "hubctl ${verb}" low level parameters (see: "hubctl ${verb} --help")
+    --tty                 Use TTY (terminal) mode for hubctl
+    --no-tty              Do not use TTY (terminal) mode for hubctl
+    --                    Separator to define "hubctl" low level parameters (see: "hubctl --help")
     -h  --help            Print this message
 
 EOF
 }
 
-
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-
-
-eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 FULL_STACK=true
 HUB_OPTS=
@@ -109,20 +108,22 @@ elif test -n "$KUBECONFIG" -a -f "$KUBECONFIG"; then
 fi
 
 if test -z "$HUB_STATE"; then
-  HUB_STATE=".hub/$HUB_DOMAIN_NAME.state"
+  HUB_STATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
 fi
+
 echo "* Using hubctl state:"
-for i in ${HUB_STATE//,/ }; do
+hub_state=$(echo "$HUB_STATE" | sed 's/,/ /g')
+for i in ${hub_state}; do
   echo "  - $i"
 done
 
 if test -z "$HUB_ELABORATE"; then
-  HUB_ELABORATE=".hub/$HUB_DOMAIN_NAME.elaborate"
+  HUB_ELABORATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate"
 fi
 echo "* Using hubctl elaborate:"
-for i in ${HUB_ELABORATE//,/ }; do
+for i in $(echo "$HUB_ELABORATE" | sed "s/,/ /g"); do
   echo "  - $i"
-  if ! grep :// <<<$i >/dev/null; then
+  if ! is_url "$i"; then
     HUB_ELABORATE_FILE=$i
   fi
 done
@@ -149,7 +150,7 @@ fi
 
 # export HUB_YAML HUB_FILES HUB_STATE HUB_ELABORATE
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 hub_backup_dir="$HUB_BACKUP_DIR"
@@ -185,7 +186,7 @@ if test -n "$HUB_BACKUP_TAG"; then
     echo "  Unlinking $tag_path"
     unlink "$tag_path"
   fi
-  echo "  Reference to backup: $(basename $HUB_BACKUP_DIR)"
+  echo "  Reference to backup: $(basename "$HUB_BACKUP_DIR")"
   mkdir -p "$(dirname "$tag_path")"
   ln -s "$HUB_BACKUP_DIR" "$tag_path"
 fi

--- a/hub-stack-backup-elaborate
+++ b/hub-stack-backup-elaborate
@@ -1,14 +1,13 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -33,8 +32,8 @@ $ hubctl stack backup elaborate BACKUP_NAME/TAG
 
 Parameters:
     -V  --verbose         Verbose outputs for debug purpose
-    --tty                 Use TTY (terminal) mode for hubctl ${verb}
-    --no-tty              Do not use TTY (terminal) mode for hubctl ${verb}
+    --tty                 Use TTY (terminal) mode for hubctl
+    --no-tty              Do not use TTY (terminal) mode for hubctl
     --                    additional arguments for "hubctl backup unbundle" command
     -h  --help            Print this message
 
@@ -44,17 +43,11 @@ EOF
   $hubctl backup unbundle -h
 }
 
-
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
-  exit 1
-fi
-eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 while test "$1" != ""; do
     case $1 in
@@ -101,7 +94,7 @@ Elaborate stack:
 EOF
 
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 # maybe tag?

--- a/hub-stack-backup-ls
+++ b/hub-stack-backup-ls
@@ -1,33 +1,31 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
-if [[ ! -f .env ]]; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-eval "$(dotenv export -f ".env" )"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 find_tags() {
-  local param
-  param="$(files abspath "$1")"
-  for f in $HUB_BACKUP_DIR/tags/*; do
+  _find_tags_param="$(files abspath "$1")"
+  for f in "$HUB_BACKUP_DIR"/tags/*; do
     if ! test -L "$f"; then continue; fi
-    if test "$(files abspath "$(readlink -n "$f")")" = "$param"; then
-      echo -n " $(basename "$f")"
+    if test "$(files abspath "$(readlink -n "$f")")" = "$_find_tags_param"; then
+      printf " %s" "$(basename "$f")"
     fi
   done
 }

--- a/hub-stack-backup-show
+++ b/hub-stack-backup-show
@@ -1,15 +1,12 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -35,15 +32,14 @@ if test -z "$1"; then
   exit 1
 fi
 
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-
-eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 if test -z "$HUB_DOMAIN_NAME"; then
-  echo "Error: HUB_DOMAIN_NAME has not been defined"
+  color error "Error: HUB_DOMAIN_NAME has not been defined"
   exit 2
 fi
 
@@ -60,18 +56,18 @@ while test "$1" != ""; do
 done
 
 if test -z "$HUB_BACKUP_NAME"; then
-  echo "Error: name of the bakcup is missing"
+  color error "Error: name of the bakcup is missing"
   usage
   exit 2
 fi
 
 if test -z "$HUB_DOMAIN_NAME"; then
-  echo "Error: HUB_DOMAIN_NAME has not been defined"
+  color error "Error: HUB_DOMAIN_NAME has not been defined"
   exit 2
 fi
 
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 backup_path="$HUB_BACKUP_DIR/$HUB_DOMAIN_NAME/$HUB_BACKUP_NAME"
@@ -80,13 +76,14 @@ if test ! -d "$backup_path"; then
 fi
 
 if test ! -d "$backup_path"; then
-  echo "Error: directory $backup_path not found"
+  color error "Error: directory $backup_path not found"
   exit 3
 fi
+
 if test -f "$backup_path/hub-bundle.yaml.gz"; then
   gunzip -c "$backup_path/hub-bundle.yaml.gz" | yq e -
 fi
 
 if test -f "$backup_path/hub-bundle.yaml"; then
-  cat "$backup_path/hub-bundle.yaml" | yq e -
+  yq e < "$backup_path/hub-bundle.yaml"
 fi

--- a/hub-stack-backup-tag
+++ b/hub-stack-backup-tag
@@ -1,15 +1,12 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -35,15 +32,14 @@ if test -z "$1"; then
   exit 1
 fi
 
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-
-eval "$(dotenv -f $HUB_WORKDIR/.env export)"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 if test -z "$HUB_DOMAIN_NAME"; then
-  echo "Error: HUB_DOMAIN_NAME has not been defined"
+  color error "Error: HUB_DOMAIN_NAME has not been defined"
   exit 2
 fi
 
@@ -64,21 +60,22 @@ done
 
 
 if test -z "$HUB_BACKUP_NAME"; then
-  echo "Error: name of the bakcup is missing"
+  color error "Error: name of the bakcup is missing"
   usage
   exit 2
 fi
 
 if test -z "$HUB_DOMAIN_NAME"; then
-  echo "Error: HUB_DOMAIN_NAME has not been defined"
+  color error "Error: HUB_DOMAIN_NAME has not been defined"
   exit 2
 fi
 
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
+
 if test -z "$HUB_BACKUP_TAG"; then
-  echo "Error: backup tag has not been defined"
+  color error "Error: backup tag has not been defined"
   usage
   exit 4
 fi
@@ -86,7 +83,7 @@ fi
 backup_path="$HUB_BACKUP_DIR/$HUB_DOMAIN_NAME/$HUB_BACKUP_NAME"
 tag_path="$HUB_BACKUP_DIR/tags/$HUB_BACKUP_TAG"
 if test ! -d "$backup_path"; then
-  echo "Error: directory $backup_path not found"
+  color error "Error: directory $backup_path not found"
   exit 3
 fi
 
@@ -95,6 +92,6 @@ if test -L "$tag_path"; then
   echo "  Unlinking $tag_path"
   unlink "$tag_path"
 fi
-echo "  Reference to bakup: $(basename $backup_path)"
+echo "  Reference to bakup: $(basename "$backup_path")"
 mkdir -p "$(dirname "$tag_path")"
 ln -s "$backup_path" "$tag_path"

--- a/hub-stack-backup-untag
+++ b/hub-stack-backup-untag
@@ -1,15 +1,12 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -49,24 +46,24 @@ done
 
 
 if test -z "$HUB_BACKUP_TAG"; then
-  echo "Error: tag name is missing"
+  color error "Error: tag name is missing"
   usage
   exit 2
 fi
 
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
-eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
 if test -z "$HUB_BACKUP_DIR"; then
-  HUB_BACKUP_DIR=".hub/backups"
+  HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
 fi
 
 tag_path="$HUB_BACKUP_DIR/tags/$HUB_BACKUP_TAG"
 if test ! -L "$tag_path"; then
-  echo "Error: $HUB_BACKUP_TAG not found"
+  color error "Error: $HUB_BACKUP_TAG not found"
   exit 3
 fi
 

--- a/hub-stack-deploy
+++ b/hub-stack-deploy
@@ -3,18 +3,15 @@
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 HUB_MANUAL_ELABORATE="${HUB_MANUAL_ELABORATE:-"1"}"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
-export PATH HUB_WORKDIR
-DOT_ENV="$(files abspath .env)"
-export DOT_ENV
+DOT_ENV="$(files abspath "$HUB_WORKDIR/.env")"
+export PATH HUB_WORKDIR DOT_ENV
 
 hubctl="$(which hubctl 2>/dev/null || true)"
 if test -z "$hubctl"; then
@@ -69,26 +66,23 @@ if test -z "$maybe_verb"; then
 fi
 verb="$maybe_verb"
 
-eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
-
-FULL_STACK=true
-WORKDIR=$(pwd)
+FULL_STACK="true"
 HUB_OPTS=
-VERBOSE=false
+VERBOSE="false"
 
 while test "$1" != ""; do
     case $1 in
         -c | --component )  shift
                             HUB_OPTS="$HUB_OPTS -c $1"
-                            FULL_STACK=false
+                            FULL_STACK="false"
                             ;;
         -o | --offset )     shift
                             HUB_OPTS="$HUB_OPTS -o $1"
-                            FULL_STACK=false
+                            FULL_STACK="false"
                             ;;
         -l | --limit )      shift
                             HUB_OPTS="$HUB_OPTS -l $1"
-                            FULL_STACK=false
+                            FULL_STACK="false"
                             ;;
         --tty )             HUB_OPTS="$HUB_OPTS --tty true"
                             ;;
@@ -97,7 +91,7 @@ while test "$1" != ""; do
         --profile )         shift
                             export HUB_DEPLOY_PROFILE="$1"
                             ;;
-        -V | --verbose )    VERBOSE=true
+        -V | --verbose )    VERBOSE="true"
                             ;;
         -h | --help )       usage
                             exit
@@ -133,21 +127,24 @@ EOF
 trap 'finalize $?' EXIT
 
 if test "$VERBOSE" = "true"; then
+  export VERBOSE
   set -x
 fi
 
-if test ! -f .env; then
+if test ! -f "$DOT_ENV"; then
 color e << EOF
-Stack configuration (.env)
+Stack configuration ($DOT_ENV)
 
 To resolve please run:
-  $ hubctl configure -f hub.yaml
+  $ hubctl stack init
 
 To explore more configuration options:
-  $ hubctl configure -f hub.yaml --help
+  $ hubctl stack init --help
 EOF
   exit 1
 fi
+
+eval "$(dotenv export -f "$DOT_ENV")"
 
 if test -z "$HUB_FILES"; then
   color e << EOF
@@ -156,21 +153,21 @@ Cannot find hubctl definition files (HUB_FILES) in .env"
 Probably because stack has not been initialized for deployment yet!
 
 Example:
-  $ hubctl stack init -f hub.yaml
+  $ hubctl stack init
 
 To explore more configuration options:
-  $ hubctl stack init -f hub.yaml --help
-EOF
+  $ hubctl stack init --help
 
+EOF
   exit 2
 fi
 
 if test "$HUB_AUTOCONFIGURE" = "1"; then
-  printf "Proceeding with:"; color h "configure"
+  printf "Proceeding with: "; color h "configure"
   $hubctl stack configure "$(test "$VERBOSE" = "true" && echo "--verbose")"
   echo "Reloading .env file"
-  eval "$(dotenv -f $HUB_WORKDIR/.env "export")"
-  printf "Proceeding with:"; color h "$verb"
+  eval "$(dotenv export -f "$DOT_ENV")"
+  printf "Proceeding with: "; color h "$verb"
 fi
 
 if test -z "$HUB_DOMAIN_NAME"; then
@@ -211,10 +208,10 @@ fi
 HUB=${HUB:-hub}
 
 if test -z "$HUB_STATE"; then
-  HUB_STATE=".hub/$HUB_DOMAIN_NAME.state"
+  HUB_STATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
 fi
 echo "* Using hubctl state:"
-for i in $(echo $HUB_STATE | sed "s/,/ /g"); do
+for i in $(echo "$HUB_STATE" | sed "s/,/ /g"); do
   echo "  - $i"
 done
 
@@ -222,7 +219,7 @@ if test -z "$HUB_ELABORATE"; then
   HUB_ELABORATE=".hub/$HUB_DOMAIN_NAME.elaborate"
 fi
 echo "* Using hubctl elaborate:"
-for i in $(echo $HUB_ELABORATE | sed "s/,/ /g"); do
+for i in $(echo "$HUB_ELABORATE" | sed "s/,/ /g"); do
   echo "  - $i"
   if ! is_url "$i"; then
     HUB_ELABORATE_FILE=$i
@@ -234,7 +231,7 @@ if test -n "$HUB_CLOUD_PROVIDER"; then
   HUB_OPTS="--clouds=$HUB_CLOUD_PROVIDER $HUB_OPTS"
 fi
 
-if $FULL_STACK || test -n "$HUB_ELABORATE_FILE" -a ! -e "$HUB_ELABORATE_FILE"; then
+if test "$FULL_STACK" = "true" || test -n "$HUB_ELABORATE_FILE" -a ! -e "$HUB_ELABORATE_FILE"; then
   hub-stack-elaborate
 elif test -n "$HUB_ELABORATE_FILE"; then
   if ! check-elaborate "$HUB_ELABORATE_FILE" "$HUB_FILES"; then
@@ -252,9 +249,10 @@ fi
 
 export HUB_YAML HUB_FILES HUB_STATE HUB_ELABORATE
 
+# shellcheck disable=SC2086
 BEFORE=$(yq -N e .extensions.${verb}.before.[] $HUB_FILES | sort | uniq)
 for i in $(echo "$BEFORE" | xargs -n1); do
-  if test -x "$i"; then
+  if test -x "$i" -a -f "$i"; then
     hook="$i"
   else
     hook=$(files find-in-path "$i/before-${verb}")
@@ -296,6 +294,7 @@ EOF
 $lifecycle "$HUB_ELABORATE" -s "$HUB_STATE" $HUB_OPTS
 echo
 
+# shellcheck disable=SC2086
 AFTER=$(yq -N e .extensions.${verb}.after.[] $HUB_FILES | sort | uniq)
 if test -n "$AFTER"; then
   status="$(hubctl show -jq '.status.status|select(.)')"
@@ -313,7 +312,7 @@ EOF
     AFTER=""
   fi
   for i in $(echo "$AFTER" | xargs -n1); do
-    if test -x "$i"; then
+    if test -x "$i" -a -f "$i"; then
       hook="$i"
     else
       hook=$(files find-in-path "$i/after-${verb}")

--- a/hub-stack-elaborate
+++ b/hub-stack-elaborate
@@ -1,14 +1,13 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -39,11 +38,11 @@ if test -z "$hubctl"; then
   exit 1
 fi
 
-if test ! -f .env; then
-  echo "* Error: configuration '.env' has not been found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-eval "$(dotenv export -f "$HUB_WORKDIR/.env" )"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 HUB_OPTS=
 while [ "$1" != "" ]; do
@@ -84,18 +83,13 @@ EOF
 fi
 
 if test -z "$HUB_STATE"; then
-  if test -f ".hub/$HUB_DOMAIN_NAME.state"; then
-    HUB_STATE=".hub/$HUB_DOMAIN_NAME.state"
+  if test -f "$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"; then
+    HUB_STATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
   fi
 fi
 
-# if test -n "$HUB_STATE"; then
-#   echo "* Using hubctl state: $HUB_STATE"
-#   HUB_OPTS="$HUB_OPTS -s $HUB_STATE"
-# fi
-
 if test -z "$HUB_ELABORATE"; then
-  HUB_ELABORATE=".hub/$HUB_DOMAIN_NAME.elaborate"
+  HUB_ELABORATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate"
 fi
 
 cat << EOF
@@ -109,14 +103,13 @@ Proceeding with: elaborate
 EOF
 
 verb="elaborate"
-work_dir="$(pwd)"
 script_dir=$(dirname "$0")
 
-
+# shellcheck disable=SC2086
 BEFORE=$(yq -N e .extensions.${verb}.before.[] $HUB_FILES | sort | uniq)
 for i in $(echo "$BEFORE" | xargs -n1); do
-  if test -f "$work_dir/.hub/$i/before-${verb}"; then
-    hook="$work_dir/.hub/$i/before-${verb}"
+  if test -f "$HUB_WORKDIR/.hub/$i/before-${verb}"; then
+    hook="$HUB_WORKDIR/.hub/$i/before-${verb}"
   elif test -f "$script_dir/$i/before-${verb}"; then
     hook="$script_dir/$i/before-${verb}"
   else
@@ -131,10 +124,11 @@ done
 # shellcheck disable=SC2086
 $hubctl elaborate $HUB_FILES -o "$HUB_ELABORATE" $HUB_OPTS
 
+# shellcheck disable=SC2086
 AFTER=$(yq -N e .extensions.${verb}.after.[] $HUB_FILES | sort | uniq)
 for i in $(echo "$AFTER" | xargs -n1); do
-  if test -f "$work_dir/.hub/$i/after-${verb}"; then
-    hook="$work_dir/.hub/$i/after-${verb}"
+  if test -f "$HUB_WORKDIR/.hub/$i/after-${verb}"; then
+    hook="$HUB_WORKDIR/.hub/$i/after-${verb}"
   elif test -f "$script_dir/$i/after-${verb}"; then
     hook="$script_dir/$i/after-${verb}"
   else

--- a/hub-stack-explain
+++ b/hub-stack-explain
@@ -1,14 +1,14 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -53,10 +53,11 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if test ! -f .env; then
-    echo "* Error: configuration '.env' not found"
-    exit 1
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
 fi
-eval "$(dotenv export -f "$HUB_WORKDIR/.env" )"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
+# shellcheck disable=SC2086
 $hubctl explain "$HUB_ELABORATE" "$HUB_STATE" $HUB_OPTS | less -R

--- a/hub-stack-init
+++ b/hub-stack-init
@@ -5,11 +5,9 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# shellcheck disable=SC2016,SC2068,SC2086
-
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH HUB_HOME HUB_EXTENSION
@@ -38,7 +36,7 @@ maybe_download() {
   elif is_url "$1"; then
     files download "$1" "$filepath"
     echo "(downloaded)"
-    KNOWN_URLS=$(dirname $1 | xargs)
+    KNOWN_URLS=$(dirname "$1" | xargs)
   else
     for url in $KNOWN_URLS; do
       # shellcheck disable=SC2001
@@ -63,6 +61,7 @@ if test -z "$hubctl"; then
 fi
 
 real_files() {
+  # shellcheck disable=SC2068
   for f in $@; do
     if test -f "$f"; then
       printf " %s" "$f"
@@ -96,6 +95,7 @@ State ref:
 EOF
 
   if test -n "$@"; then
+    # shellcheck disable=SC2068
     for req in $@; do
       init=$(files find-in-path "$req/init")
       if test -n "$init"; then
@@ -121,10 +121,8 @@ ident() {
 
 finalize() {
   rv="$?"
+  # shellcheck disable=SC2068
   rm -rf $@
-  # if test "$rv" != "0"; then
-  #   color e "Finished wih error!"
-  # fi
   exit $rv
 }
 
@@ -136,7 +134,7 @@ HUB_INTERACTIVE="${HUB_INTERACTIVE:-1}"
 bubbles_new_name="$(files -e find-in-path bubble-dns/new-name)"
 bubbles_new_domain="$(files -e find-in-path bubble-dns/new)"
 
-while [ "$1" != "" ]; do
+while test "$1" != ""; do
   case "$1" in
     -f | --file )
       shift
@@ -148,10 +146,6 @@ while [ "$1" != "" ]; do
         fi
       fi
       ;;
-    # -s | --state )
-    #   shift
-    #   SOURCE_HUB_STATE="$1"
-    #   ;;
     --force )
       HUB_USE_FORCE="1"
       ;;
@@ -172,17 +166,17 @@ while [ "$1" != "" ]; do
       else
         SOURCE_HUB_STATE="$1"
       fi
+      shift
       ;;
   esac
-  shift
 done
 
 if $VERBOSE; then
   set -x
 fi
 
-if test -z "$HUB_FILES" -a -f "hub.yaml"; then
-  HUB_FILES="hub.yaml"
+if test -z "$HUB_FILES" -a -f "$HUB_WORKDIR/hub.yaml"; then
+  HUB_FILES="$HUB_WORKDIR/hub.yaml"
 fi
 
 if test -f "$HUB_WORKDIR/.env" -a -z "$HUB_USE_FORCE"; then
@@ -234,6 +228,7 @@ EXPANDED=""
 export DOT_ENV
 
 expand_hub_files() {
+  # shellcheck disable=SC2068
   for f in $@; do
     if test -z "$f"; then continue; fi
     if echo "$EXPANDED" | grep -q "$f"; then continue; fi
@@ -244,6 +239,7 @@ expand_hub_files() {
       EXPANDED=$(echo "$EXPANDED $f" | xargs)
       included="$(to_json "$f" | jq -cMr '.extensions.include|select(.)[]')"
       if test -n "$included"; then
+        # shellcheck disable=SC2086
         expand_hub_files $included
       fi
     elif maybe_download "$f"; then
@@ -318,7 +314,7 @@ else
   echo "Initializing a new stack"
 fi
 
-printf "Using working directory"
+printf "Using working directory "
 color b "$HUB_WORKDIR"
 if test -L "$HUB_WORKDIR/.env"; then
   echo "* Unlinking .env"
@@ -328,26 +324,25 @@ elif test -f "$HUB_WORKDIR/.env" ; then
   rm -rf "$HUB_WORKDIR/.env"
 fi
 
+# shellcheck disable=SC2086
 expand_hub_files $HUB_FILES
+# shellcheck disable=SC2086
 HUB_FILES="$(real_files $EXPANDED | xargs)"
 params="params -S"
 export HUB_FILES
 
-# mkdir -p "$HUB_WORKDIR/.hub/env"
-# if test -x "$HUB_WORKDIR/.hub/before-init"; then
-#   echo "Running before init script..."
-#   $HUB_WORKDIR/.hub/before-init
-# fi
-
+# shellcheck disable=SC2086
 HUB_STACK_REQUIRES="$(yq e '' $HUB_FILES -o json | jq -cMr 'select(.extensions).extensions | select(.init).init[]')"
 for req in $HUB_STACK_REQUIRES; do
   init=$(files find-in-path "$req/init")
   if test -x "$HUB_WORKDIR/$req"; then
     color b "* Running init script $req"
-    $HUB_WORKDIR/$req $ARGS
+    # shellcheck disable=SC2086
+    "$HUB_WORKDIR/$req" $ARGS
   elif test -n "$init"; then
     printf "Initializing "
     color h "$req"
+    # shellcheck disable=SC2086
     $init $ARGS
   else
     color w "Cannot find neither init script $req neither extension $req/init"
@@ -504,7 +499,7 @@ if test -n "$HUB_STATE"; then
       continue
     fi
     for state in $HUB_STATE; do
-      if test ! -f $state; then
+      if test ! -f "$state"; then
         continue
       fi
 
@@ -539,7 +534,7 @@ This may overwrite settings
 
 If you want to use the stack then run the following:
 
-  hubctl stack set $HUB_DOMAIN_NAME
+  hubctl stack use $HUB_DOMAIN_NAME
 
 EOF
   exit 1
@@ -552,7 +547,7 @@ fi
 
 echo "Checking hooks"
 for hubfile in $HUB_FILES; do
-  for hook in $(to_json $hubfile | getConfigureScripts); do
+  for hook in $(to_json "$hubfile" | getConfigureScripts); do
     printf "* Checking configure %s " "$hook"
     if files -e find-in-path "$hook/configure" > /dev/null; then
       echo "(extension)"
@@ -562,7 +557,7 @@ for hubfile in $HUB_FILES; do
       color w "Warning: $hook not found"
     fi
   done
-  for hook in $(to_json $hubfile | getDeployHooks "before"); do
+  for hook in $(to_json "$hubfile" | getDeployHooks "before"); do
     printf "* Checking deploy before %s " "$hook"
     if files -e find-in-path "$hook/before-deploy" > /dev/null; then
       echo "(extension)"
@@ -572,7 +567,7 @@ for hubfile in $HUB_FILES; do
       color w "Warning: $hook not found"
     fi
   done
-  for hook in $(to_json $hubfile | getDeployHooks "after"); do
+  for hook in $(to_json "$hubfile" | getDeployHooks "after"); do
     printf "* Checking deploy after %s " "$hook"
     if files -e find-in-path "$hook/after-deploy" > /dev/null; then
       echo "(extension)"
@@ -582,7 +577,7 @@ for hubfile in $HUB_FILES; do
       color w "Warning: $hook not found"
     fi
   done
-  for hook in $(to_json $hubfile | getAllComponentHooks); do
+  for hook in $(to_json "$hubfile" | getAllComponentHooks); do
     printf "* Checking component %s " "$hook"
     if maybe_download "$hook"; then
       chmod +x "$hook"
@@ -594,20 +589,18 @@ done
 
 echo "Checking components"
 for hubfile in $HUB_FILES; do
-  if test ! -f $hubfile; then
+  if test ! -f "$hubfile"; then
     color warn "* Warning: skipping $hubfile due to not found"
     continue
   fi
-  # hubfile_dir="$(dirname "$(files abspath "$hubfile")")"
   for comp in $(to_json "$hubfile" | components); do
     printf "* Component %s: " "$comp"
     _dir=$(to_json "$hubfile" | componentDir "$comp")
-    # to_json "$hubfile" | componentDir "$comp"
     if test -z "$_dir"; then
       color w "Warning: component $comp has no directory"
       exit 1
     fi
-    comp_dir=$(files relpath "$_dir" "$HUB_WORKDIR")
+    comp_dir="$HUB_WORKDIR/$_dir"
 
     if test -d "$comp_dir"; then
       echo "exist"
@@ -615,64 +608,50 @@ for hubfile in $HUB_FILES; do
     fi
     echo "fetching"
 
+    temp_dir=$(temp_file)
+    mkdir -p "$temp_dir";
+
     git_repo=$(to_json "$hubfile" | componentSourceRepo "git" "$comp")
     if test -n "$git_repo"; then
       subdir=$(to_json "$hubfile" | componentSourceSubdir "git" "$comp")
       ref=$(to_json "$hubfile" | componentSourceRef "git" "$comp")
-      temp_dir=$(temp_file)
-      echo "  Retrieving from git source repository"
-      echo "  Running: git clone $git_repo"
-      mkdir -p "$temp_dir";
+      cat << EOF | ident
+Retrieving from git source repository
+Running: git clone $git_repo
+EOF
       git clone $GIT_OPTS "$git_repo" "$temp_dir" >/dev/null
-      (
-        cd "$temp_dir";
-        git config advice.detachedHead "false" >/dev/null
-        head="$(git rev-parse --abbrev-ref HEAD)";
-        printf "  Using ref: ";
-        if test "$ref" = "__auto__"; then
-          color b "$head";
-        else
-          color b "$ref";
-          if test "$head" != "$ref"; then
-            git fetch $GIT_OPTS --all --tags >/dev/null;
-            git checkout $GIT_OPTS "$ref" >/dev/null;
-          fi
-        fi
-      )
-
-      echo "  Saving component: $comp_dir"
-      mkdir -p "$comp_dir"
-      cp -rf "$temp_dir/$subdir/." "$comp_dir"
-      continue
     fi
 
     gcp_repo=$(to_json "$hubfile" | componentSourceRepo "gcp" "$comp")
     if test -n "$gcp_repo"; then
       subdir=$(to_json "$hubfile" | componentSourceSubdir "gcp" "$comp")
       ref=$(to_json "$hubfile" | componentSourceRef "gcp" "$comp")
-      temp_dir=$(temp_file)
-      echo "  Retrieving from gcp source repository"
-      echo "  Running: gcloud source repos clone $gcp_repo"
+      cat << EOF | ident
+Retrieving from gcp source repository
+Running: gcloud source repos clone $gcp_repo
+EOF
       gcloud --no-user-output-enabled source repos clone "$gcp_repo" "$temp_dir"
-      (
-        cd "$temp_dir";
-        head="$(git rev-parse --abbrev-ref HEAD)";
-        printf "  Using ref: ";
-        if test "$ref" = "__auto__"; then
-          color b "$head";
-        else
-          color b "$ref";
-          if test "$head" != "$ref"; then
-            git fetch $GIT_OPTS --all --tags >/dev/null;
-            git checkout $GIT_OPTS "$ref" -b "$ref" >/dev/null;
-          fi
-        fi
-      )
-      echo "  Saving component: $comp_dir"
-      mkdir -p "$HUB_WORKDIR/$comp_dir"
-      cp -rf "$temp_dir/$subdir/." "$HUB_WORKDIR/$comp_dir"
-      continue
     fi
+
+    (
+      cd "$temp_dir";
+      head="$(git rev-parse --abbrev-ref HEAD)";
+      printf "  Using ref: ";
+      if test "$ref" = "__auto__"; then
+        color b "$head";
+      else
+        color b "$ref";
+        if test "$head" != "$ref"; then
+          git fetch $GIT_OPTS --all --tags >/dev/null;
+          git checkout $GIT_OPTS "$ref" -b "$ref" >/dev/null;
+        fi
+      fi
+    )
+
+    echo "  Saving component: $comp_dir"
+    mkdir -p "$comp_dir"
+    cp -rf "$temp_dir/$subdir/." "$comp_dir"
+    continue
   done
 done
 dotenv set "HUB_AUTOCONFIGURE" "$HUB_AUTOCONFIGURE"
@@ -685,17 +664,12 @@ if test -n "$HUB_STATE"; then
 fi
 echo "Saving configuration"
 temp="$(temp_file)"
-HUB_DOMAIN_NAME=$(dotenv -f "DOT_ENV" get "HUB_DOMAIN_NAME" --default "$HUB_DOMAIN_NAME")
-dotenv merge -f "$DOT_ENV" -f ".hub/env/$HUB_DOMAIN_NAME.env" > "$temp"
+HUB_DOMAIN_NAME=$(dotenv -f "$DOT_ENV" get "HUB_DOMAIN_NAME" --default "$HUB_DOMAIN_NAME")
+dotenv merge -f "$DOT_ENV" -f "$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.env" > "$temp"
 echo "* Saving configuration to .hub/env/$HUB_DOMAIN_NAME.env"
 files copy "$temp" "$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.env" | ident
 update_symlink "$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.env" "$HUB_WORKDIR/.env"
 
-# if test -x "$HUB_WORKDIR/.hub/after-init"; then
-#   export DOT_ENV="$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.env"
-#   color w "Deprecated functionality: after-init will be removed "
-#   $HUB_WORKDIR/.hub/after-init
-# fi
 cat << EOF
 
 Stack has been initialized!

--- a/hub-stack-invoke
+++ b/hub-stack-invoke
@@ -1,14 +1,14 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -29,7 +29,7 @@ cat << EOF
 Invoke stack component's verb
 
 Usage:
-$ hubctl stack invoke <component> <verb>
+$ $HUB_EXTENSION <component> <verb>
 
 Parameters:
     -V  --verbose          Verbose outputs for debug purpose
@@ -54,11 +54,11 @@ while [ "$1" != "" ]; do
     shift
 done
 
-if test ! -f .env; then
-    echo "* Error: configuration '.env' not found"
+if test ! -f "$HUB_WORKDIR/.env"; then
+    color error "Error: cannot find .env file in $HUB_WORKDIR"
     exit 1
 fi
-eval "$(dotenv export -f "$HUB_WORKDIR/.env" )"
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 cat << EOF
 Invoking $verb:

--- a/hub-stack-ls
+++ b/hub-stack-ls
@@ -3,7 +3,7 @@
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
@@ -21,12 +21,12 @@ if test -z "$hubctl"; then
 fi
 
 CURRENT=""
-if test -f ".env"; then
-  CURRENT=$(basename "$(readlink .env)" .env)
+if test -f "$HUB_WORKDIR/.env"; then
+  CURRENT=$(basename "$(readlink "$HUB_WORKDIR/.env")" .env)
 fi
 
-if test ! -d .hub/env; then
-  color e  "No stacks available"
+if test ! -d "$HUB_WORKDIR/.hub/env"; then
+  color e "No stacks available"
   exit 1
 fi
 
@@ -60,9 +60,8 @@ temp_file() {
 
 print_stacks() {
   echo "ACTIVE|STACK|STATUS|TIMESTAMP"
-  if test -d ".hub/env"; then
-    # shellcheck disable=SC2045
-    for f in $(ls -t .hub/env/*.env .hub/env/.env 2>/dev/null); do
+  if test -d "$HUB_WORKDIR/.hub/env"; then
+    for f in "$HUB_WORKDIR"/.hub/env/*.env "$HUB_WORKDIR"/.hub/env/.env; do
       if test ! -f "$f"; then
         continue
       fi

--- a/hub-stack-rm
+++ b/hub-stack-rm
@@ -1,14 +1,14 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH HUB_WORKDIR
 
@@ -26,7 +26,7 @@ Parameters:
 EOF
 }
 
-DOT_ENV=".env"
+DOT_ENV="$HUB_WORKDIR/.env"
 while [ "$1" != "" ]; do
     case $1 in
     -V | --verbose )    set -x
@@ -34,9 +34,9 @@ while [ "$1" != "" ]; do
     -h | --help )       usage
                         exit
                         ;;
-    initialized )       DOT_ENV=".hub/env/.env"
+    initialized )       DOT_ENV="$HUB_WORKDIR/.hub/env/.env"
                         ;;
-    * )                 DOT_ENV=".hub/env/$1.env"
+    * )                 DOT_ENV="$HUB_WORKDIR/.hub/env/$1.env"
                         ;;
     esac
     shift
@@ -58,7 +58,7 @@ in_directory() {
 
 rm_in_workdir() {
   if test -L "$1"; then
-    rm_in_workdir "$(readlinkreadlink -n "$1")"
+    rm_in_workdir "$(readlink -n "$1")"
     echo "* Unlinking: $f"
     unlink "$1"
   elif test -f "$1"; then
@@ -66,13 +66,13 @@ rm_in_workdir() {
       echo "* Removing: $1"
       rm -rf "$1"
     else
-      color w "Skipping $1 (not in .hub directory)"
+      color w "Skipping $1 (not in $HUB_WORKDIR/.hub directory)"
     fi
   fi
 }
 
 if test -L "$DOT_ENV" -a ! -e "$DOT_ENV"; then
-  echo "* Unlinking: .env"
+  echo "* Unlinking: $HUB_WORKDIR/.env"
   unlink "$HUB_WORKDIR/.env"
   exit
 fi
@@ -95,14 +95,14 @@ dotenv="dotenv -f $DOT_ENV"
 HUB_DOMAIN_NAME="$($dotenv get "HUB_DOMAIN_NAME")"
 if test -z "$HUB_DOMAIN_NAME"; then
   HUB_DOMAIN_NAME="$($dotenv get "HUB_STACK_NAME")"
-  if test -L .env; then
-    FILES="$FILES $(readlink -n .env)"
+  if test -L "$HUB_WORKDIR/.env"; then
+    FILES="$FILES $(readlink -n "$HUB_WORKDIR/.env")"
   fi
 fi
 
 if test -n "$HUB_DOMAIN_NAME"; then
   echo "Removing configuration for: $HUB_DOMAIN_NAME"
-  FILES="$FILES $(find .hub -name "$HUB_DOMAIN_NAME.*" -print0  | xargs -0)"
+  FILES="$FILES $(find "$HUB_WORKDIR/.hub" -name "$HUB_DOMAIN_NAME.*" -print0  | xargs -0)"
 else
   echo "Removing configuration for: initialized"
 fi
@@ -127,7 +127,7 @@ for f in $FILES; do
   rm_in_workdir "$f"
 done
 
-if test -L ".env" -a ! -e ".env"; then
+if test -L "$HUB_WORKDIR/.env" -a ! -e "$HUB_WORKDIR/.env"; then
   echo "* Unlinking: .env"
   unlink "$HUB_WORKDIR/.env"
 fi

--- a/hub-stack-use
+++ b/hub-stack-use
@@ -1,18 +1,19 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2023 EPAM Systems, Inc.
 #
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 
 usage() {
   cat << EOF
 Use or change currently active stack
 
-Usage: hubctl stack use STACK
+Usage: $HUB_EXTENSION STACK
 
   where STACK is the name of the stack to use as an active
 
@@ -34,7 +35,7 @@ else
   dotfile="$HUB_WORKDIR/.hub/env/$1.env"
 fi
 
-if test ! -d .hub/env; then
+if test ! -d "$HUB_WORKDIR/.hub/env"; then
   color error "Error: no stacks available"
   exit 2
 fi
@@ -53,15 +54,15 @@ EOF
 fi
 
 
-if test -L ".env"; then
+if test -L "$HUB_WORKDIR/.env"; then
   echo "* Unlinking .env"
-  unlink ".env"
-elif test -f ".env"; then
+  unlink "$HUB_WORKDIR/.env"
+elif test -f "$HUB_WORKDIR/.env"; then
   echo "* Backing up .env as .env.bak"
-  mv ".env" ".env.bak"
+  mv "$HUB_WORKDIR/.env" "$HUB_WORKDIR/.env.bak"
 fi
 
-if test ! -f ".env"; then
+if test ! -f "$HUB_WORKDIR/.env"; then
   echo "* Setting .env link to $1"
-  ln -sf "$dotfile" ".env"
+  ln -sf "$dotfile" "$HUB_WORKDIR/.env"
 fi

--- a/hub-toolbox
+++ b/hub-toolbox
@@ -8,12 +8,11 @@
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
-HUB_EXTENSION="$(basename "$0" | sed 's/-/ /g')"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
 HUB_MANUAL_ELABORATE="${HUB_MANUAL_ELABORATE:-"1"}"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
-export PATH HUB_WORKDIR
-DOT_ENV="$(files abspath .env)"
-export DOT_ENV
+DOT_ENV="$(files abspath "$HUB_WORKDIR/.env")"
+export PATH HUB_WORKDIR DOT_ENV
 
 usage() {
 cat << EOF

--- a/hub-vault
+++ b/hub-vault
@@ -1,20 +1,25 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
+HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
+HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
+HUB_EXTENSION="$(basename "$0" | sed 's/hub-/hubctl-/g' | sed 's/-/ /g')"
+PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
+export PATH
 
 usage() {
 cat << EOF
 Wrapper script around vault. With only difference it uses a port-forward
 
-Usage: 
-  $(basename "$0") [args] [vault sub-command] [vault args]
+Usage:
+  $HUB_EXTENSION [args] [vault sub-command] [vault args]
 
 Current kubecontext:
-  $(basename "$0") [no arg] or [-c _] or [--current-kubecontext]
+  $HUB_EXTENSION [no arg] or [-c _] or [--current-kubecontext]
 
 Parameters:
   -n --namespace         Vault namespace
@@ -27,12 +32,13 @@ Parameters:
   -V --verbose           Add some verbosity to output
   -h --help              Print this message
 
-Example: 
-  $(basename "$0") [-c _] status
-  $(basename "$0") [-c _] -S svc/vault list
+Example:
+  $HUB_EXTENSION [-c _] status
+  $HUB_EXTENSION [-c _] -S svc/vault list
 
-Sub-command $(basename "$0"):
+Sub-command $HUB_EXTENSION:
 EOF
+  # shellcheck disable=SC2086
   vault $VAULT_ARGS --help
 }
 
@@ -42,17 +48,20 @@ VAULT_SVC="svc/vault"
 SILENT=${SILENT:-false}
 VAULT_ARGS=
 
-# shellcheck disable=SC1091
-test ! -f ".env" || source ".env"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
+fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 while [ "$1" != "" ]; do
   case "$1" in
     -n | --namespace )      shift
                             namespace="$1"
-                            ;; 
+                            ;;
     -k | --kubeconfig )     shift
                             export KUBECONFIG="$1"
-                            ;; 
+                            ;;
     -c | --kubecontext )    shift
                             context="$1"
                             ;;
@@ -74,11 +83,11 @@ while [ "$1" != "" ]; do
   shift
 done
 
-if test "$context" == "_"; then
+if test "$context" = "_"; then
   context="$(kubectl config current-context)"
 fi
 
-$SILENT || cat << EOF 
+$SILENT || cat << EOF
 Proceeding to initialize: $VAULT_SVC
 * Using context: $context
 * Using namespace: $namespace
@@ -90,26 +99,26 @@ export VAULT_ADDR
 
 KUBECTL=${KUBECTL:-kubectl --context="$context" --namespace="$namespace"}
 
-$SILENT || echo -n "* Using service: $VAULT_SVC"
+$SILENT || echo "* Using service: $VAULT_SVC"
 set +e
-SERVICE_PAYLOAD=$($KUBECTL get -o json $VAULT_SVC)
+SERVICE_PAYLOAD=$($KUBECTL get -o json "$VAULT_SVC")
 if test "$?" != "0"; then
-  $SILENT || echo " Error: cannot find service $COMPONENT_NAME"
+  $SILENT || color error "Error: cannot find service $COMPONENT_NAME"
   exit 2
 fi
 set -e
 
-VAULT_PORT=$(echo $SERVICE_PAYLOAD \
+VAULT_PORT=$(echo "$SERVICE_PAYLOAD" \
              | jq -r '.spec.ports[] | select(.name=="http").port | if . == "" then 8200 else . end' \
             )
 
 connect() {
   trap 'kill $(jobs -p) || exit 0' EXIT
-  $SILENT || echo -n "* Starting port forwarding to $1: "
+  $SILENT || printf "* Starting port forwarding to %s: " "$1"
   success=false
   kfctl_pid=0
   for _ in $(seq 30); do
-    $SILENT || echo -n "."
+    $SILENT || printf "."
     if ! ps -p $kfctl_pid > /dev/null; then
       $KUBECTL port-forward "$VAULT_SVC" "$1:$VAULT_PORT" >/dev/null 2>&1 &
       kfctl_pid=$!
@@ -125,17 +134,16 @@ connect() {
   done
 
   if ! $success; then
-    $SILENT || echo " Error"
-    $SILENT || echo "Timed out trying to establish port forwarding to vault"
+    $SILENT || color error "Error: Timed out trying to establish port forwarding to vault"
     exit 1
   fi
-  $SILENT || echo " Done"
+  $SILENT || echo "done"
 }
 
 $SILENT || echo ":$VAULT_PORT"
 connect "$VAULT_LOCAL_PORT"
 if ! $SILENT; then
-  echo -n "* Checking vault at $VAULT_ADDR: "
+  printf "* Checking vault at %s: " "$VAULT_ADDR"
   # see: https://www.vafultproject.io/api-docs/system/health#read-health-information
   code=$(curl -sLko /dev/null -w "%{http_code}" "$VAULT_ADDR/v1/sys/health")
   case "$code" in

--- a/inventory-configmap/apply
+++ b/inventory-configmap/apply
@@ -1,11 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086,SC2064,SC2046
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
@@ -42,13 +40,11 @@ fi
 
 echo "Finalizing stack deployment"
 
-if test ! -f ".env"; then
-  echo "Error: cannot find .env file. Please run 'hubctl configure'"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
   exit 1
 fi
-set +a
-eval "$(dotenv export -f "$HUB_WORKDIR.env" )"
-set -a
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 if test -n "$HUB_KUBECONTEXT"; then
   echo "* Setting kubecontext to: $HUB_KUBECONTEXT"
@@ -62,24 +58,26 @@ if test -f "$HUB_DOMAIN_NAME"; then
 fi
 
 if test -z "$HUB_ELABORATE"; then
-  echo "Error: cannot find elaborate file: '$HUB_ELABORATE'"
+  color e "Error: cannot find elaborate file: '$HUB_ELABORATE'"
   exit 2
 fi
 
 if test -z "$HUB_STATE"; then
-  echo "Error: cannot find state file: '$HUB_STATE'"
+  color e "Error: cannot find state file: '$HUB_STATE'"
   exit 2
 fi
 
 ns="kube-system"
-cm="superhub"
+cm="hubctl"
+# shellcheck disable=SC2086
 explained=$($HUB explain $HUB_ELABORATE $HUB_STATE --json -g | base64 | tr -d \\n)
 
-echo -n "* Saving state in $ns/$cm configmap: "
+printf "* Saving state in %s/%s configmap: " "$ns" "$cm"
 if kubectl -n $ns get configmap $cm >/dev/null 2>&1; then
   kubectl -n $ns get configmap $cm -o json |
     jq ".data += {\"${HUB_DOMAIN_NAME}\": \"${explained}\"}" |
     kubectl -n $ns replace -f -
 else
+  # shellcheck disable=SC2086
   kubectl -n $ns create configmap $cm --from-literal=${HUB_DOMAIN_NAME}=${explained}
 fi

--- a/kubernetes/after-deploy
+++ b/kubernetes/after-deploy
@@ -1,15 +1,12 @@
-#!/bin/bash -e
+#!/bin/sh -e
 # Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-# shellcheck disable=SC2068,SC2086,SC2155
-
+HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
 dotenv="dotenv -f $HUB_WORKDIR/.env"
-
-export PATH
 
 hubctl="$(which hubctl 2>/dev/null || true)"
 if test -z "$hubctl"; then
@@ -21,31 +18,27 @@ if test -z "$hubctl"; then
   exit 1
 fi
 
-usage() {
-  echo "Check Kubernetes cluster is reachable"
-}
-
 checkCluster() {
-  local KUBECONTEXT
+  _checkCluster_KUBECONTEXT=
   if test -n "$1";then
-    KUBECONFIG="$1"
+    _checkCluster_KUBECONTEXT="$1"
     export KUBECONFIG
-    echo "* Trying kubeconfig: $KUBECONFIG"
+    echo "* Trying kubeconfig: $_checkCluster_KUBECONTEXT"
   fi
-  KUBECONTEXT="$2"
+  _checkCluster_KUBECONTEXT="$2"
 
-  if test -z "$KUBECONTEXT"; then
-    KUBECONTEXT="$(kubectl config current-context)"
+  if test -z "$_checkCluster_KUBECONTEXT"; then
+    _checkCluster_KUBECONTEXT="$(kubectl config current-context)"
   fi
 
-  if test -z "$(kubectl config view -o json | jq ".contexts[] | select(.name==\"$KUBECONTEXT\").name")"; then
-    echo "* Context $KUBECONTEXT: not found"
+  if test -z "$(kubectl config view -o json | jq ".contexts[] | select(.name==\"$_checkCluster_KUBECONTEXT\").name")"; then
+    echo "* Context $_checkCluster_KUBECONTEXT: not found"
     return 1
   fi
-  echo "* Context $KUBECONTEXT: exist"
+  echo "* Context $_checkCluster_KUBECONTEXT: exist"
 
-  echo -n "* Checking connectivty to $KUBECONTEXT: "
-  if kubectl cluster-info --context="$KUBECONTEXT"> /dev/null; then
+  printf "* Checking connectivty to %s: " "$_checkCluster_KUBECONTEXT"
+  if kubectl cluster-info --context="$_checkCluster_KUBECONTEXT"> /dev/null; then
     echo "connected"
   else
     return $?
@@ -67,11 +60,11 @@ checkClusterAndSave() {
   fi
 }
 
-if test -f "$HUB_WORKDIR/.env"; then
-  set +a
-  eval "$($dotenv export)"
-  set -a
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
 fi
+eval "$($dotenv export)"
 
 echo "Finalizing kubernetes deployment"
 
@@ -86,7 +79,7 @@ else
   echo "* File .env does not provide HUB_KUBECONFIG"
 fi
 
-SAVETO="$(pwd)/.hub/env/$HUB_DOMAIN_NAME.kubeconfig"
+SAVETO="$HUB_WORKDIR/.hub/env/$HUB_DOMAIN_NAME.kubeconfig"
 if test -f "$SAVETO"; then
   if checkClusterAndSave "$SAVETO"; then
     exit 0
@@ -96,7 +89,7 @@ else
 fi
 
 if test -z "$HUB_STATE"; then
-  HUB_STATE=".hub/$HUB_DOMAIN_NAME.state"
+  HUB_STATE="$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.state"
 fi
 
 cat << EOF
@@ -143,5 +136,5 @@ if test -d "/var/run/secrets/kubernetes.io/serviceaccount"; then
   fi
 fi
 
-echo "Error: unable to configure kubeconfig!"
+color error "Error: unable to configure kubeconfig!"
 exit 1

--- a/kubernetes/before-deploy
+++ b/kubernetes/before-deploy
@@ -1,40 +1,31 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2068,SC2086,SC2155
-
-usage() {
-  cat << EOF
-Check if kubernetes cluster has been reachable
-EOF
-}
-
-if test ! -f ".env"; then
-  color err "Error: cannot find .env file. Please run 'hubctl stack configure'"
-  exit 1
-fi
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 dotenv="dotenv -f $HUB_WORKDIR/.env"
-set +a
-eval "$($dotenv "export")"
-set -a
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
+fi
+eval "$($dotenv export)"
 
 hub_kubeconfig=$($dotenv get "HUB_KUBECONFIG")
 if test -n "$hub_kubeconfig"; then
   KUBECONFIG=$($dotenv get "HUB_KUBECONFIG" --default "$KUBECONFIG")
   export KUBECONFIG
-  echo -n "* Using kubeconfig:"
+  printf "* Using kubeconfig:"
   color bold "$KUBECONFIG"
 else
-  color warn "* Warning: expected variable HUB_KUBECONFIG has not been found in .env file"
-  color warn "  This may lead to invalid deployment of the kubenretes components"
+  cat << EOF | color warn
+* Warning: expected variable HUB_KUBECONFIG has not been found in .env file"
+  This may lead to invalid deployment of the kubenretes components"
+EOF
 fi
 
-echo -n "* Checking connectivity to cluster: "
+printf "* Checking connectivity to cluster: "
 if kubectl cluster-info > /dev/null; then
   color bold "Connected"
 else
@@ -42,7 +33,7 @@ else
 fi
 
 if test "$(kubectl config current-context)" != "$HUB_DOMAIN_NAME"; then
-  echo -n "* Setting $HUB_DOMAIN_NAME kube-context to: "
+  printf "* Setting %s kube-context to: " "$HUB_DOMAIN_NAME"
   if ! kubectl config set-context "$HUB_DOMAIN_NAME"; then
     color warn "* Warning: encountered error setting kubectontext to $HUB_DOMAIN_NAME"
   fi

--- a/kubernetes/configure-local-sa
+++ b/kubernetes/configure-local-sa
@@ -1,11 +1,9 @@
-#!/bin/bash -e
-# Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#!/bin/sh -e
+# Copyright (c) 2023 EPAM Systems, Inc.
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
-# shellcheck disable=SC2086,SC2064,SC2046
+# file, You can obtain one at https://www.mozilla.org/en-US/MPL/2.0/.
 
 DOT_ENV=${DOT_ENV:-".env"}
 while [ "$1" != "" ]; do
@@ -24,13 +22,14 @@ if test "$VERBOSE" = "true"; then
 fi
 
 http_ping() {
-  local http_code rv
-  echo -n "* Trying to reach host \"$1\"... "
+  _http_ping_http_code=
+  _http_ping_rv=
+  printf "* Trying to reach host \"%s\"... " "$1"
   set +e
-  http_code=$(curl -sLko  /dev/null -w '%{http_code}' "$1")
-  rv=$?
+  _http_ping_http_code=$(curl -sLko /dev/null -w '%{http_code}' "$1")
+  _http_ping_rv=$?
   set -e
-  if test "$rv" = "0" && test "$http_code" != "000"; then
+  if test "$_http_ping_rv" = "0" && test "$_http_ping_http_code" != "000"; then
     echo "ok"
   else
     echo "not found"
@@ -38,13 +37,13 @@ http_ping() {
   fi
 }
 
-dotenv="dotenv -f $DOT_ENV)"
+dotenv="dotenv -f $DOT_ENV"
 HUB_DOMAIN_NAME=${HUB_DOMAIN_NAME:-$($dotenv get "HUB_DOMAIN_NAME")}
 SERVICEACCOUNT="/var/run/secrets/kubernetes.io/serviceaccount"
 CLUSTER="this-cluster"
 USER="${USER:-this-user}"
-echo -n "* Using service account: $SERVICEACCOUNT"
-if test -d $SERVICEACCOUNT; then
+printf "* Using service account: %s" "$SERVICEACCOUNT"
+if test -d "$SERVICEACCOUNT"; then
   echo
 else
   echo " (not found)"
@@ -67,7 +66,7 @@ if ! http_ping "$APISERVER"; then
   fi
 fi
 
-cat <<EOF > $SAVETO
+cat <<EOF > "$SAVETO"
 {
   "apiVersion": "v1",
   "kind": "Config",
@@ -95,9 +94,9 @@ cat <<EOF > $SAVETO
 }
 EOF
 
-chmod go-rw $SAVETO
+chmod go-rw "$SAVETO"
 export KUBECONFIG="$SAVETO"
-echo -n "* Connecting to API server: "
+printf "* Connecting to API server: "
 if kubectl cluster-info > /dev/null; then
   echo "Connected"
 else

--- a/profiles/docker/deploy
+++ b/profiles/docker/deploy
@@ -30,9 +30,9 @@ if test -z "\$hubctl"; then
   hubctl="\$(which hub 2>/dev/null || true)"
 fi
 
-if test -e ".env"; then
+if test -e "\$HUB_WORKDIR/.env"; then
     set -a
-    source .env
+    source \$HUB_WORKDIR/.env
     set +a
 fi;
 

--- a/profiles/kubernetes/aws
+++ b/profiles/kubernetes/aws
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 # Copyright (c) 2022 EPAM Systems, Inc.
-# 
+#
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -26,9 +26,11 @@ if test -z "$POD"; then
   exit 1
 fi
 
-if test -f ".env"; then
-  eval "$(dotenv -f $HUB_WORKDIR/.env export)"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
 fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 # these AWS_* vars are passed into pod by ./template as we may copy files to the non-default locations
 # or switch to the default locations instead

--- a/profiles/kubernetes/impl
+++ b/profiles/kubernetes/impl
@@ -40,9 +40,11 @@ if test -z "$hubctl"; then
   exit 1
 fi
 
-if test -f ".env"; then
-  eval "$(dotenv -f "$HUB_WORKDIR/.env" export -f ".env" )"
+if test ! -f "$HUB_WORKDIR/.env"; then
+  color error "Error: cannot find .env file in $HUB_WORKDIR"
+  exit 1
 fi
+eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 TOOLBOX_NAMESPACE=${TOOLBOX_NAMESPACE:-hubctl}
 ID=$(gen_random 8)


### PR DESCRIPTION
This is big PR. I have fixed the main issue and because it involves a lot of files to edit I also performed a small refactoring.

- Now `HUB_WORKDIR` is used by extensions properly
- Most of the affected extensions moved from `bash` to `sh`