### PR TITLE
Fix small issues in utils

### DIFF
--- a/bin/color
+++ b/bin/color
@@ -55,8 +55,8 @@ while test -n "$1"; do
       shift; continue
     ;;
     -c | --color )
-      _tput setaf "$1"
       shift
+      _tput setaf "$1"
       shift; continue
     ;;
     -n )

--- a/bubble-dns/new
+++ b/bubble-dns/new
@@ -7,11 +7,11 @@
 
 # shellcheck disable=SC2046,SC2086
 
-HUB_PARENT_DOMAIN="${HUB_PARENT_DOMAIN:-"epam.devops.delivery"}"
+HUB_BASE_DOMAIN="${HUB_BASE_DOMAIN:-"epam.devops.delivery"}"
 while [ "$1" != "" ]; do
   case $1 in
     --parent-domain )   shift
-                        HUB_PARENT_DOMAIN="$1"
+                        HUB_BASE_DOMAIN="$1"
                         ;;
     --output )          shift
                         DOT_ENV="$1"
@@ -25,7 +25,7 @@ if test "$VERBOSE" = "true"; then
 fi
 
 printf "* Using parent domain: "
-color h "$HUB_PARENT_DOMAIN"
+color h "$HUB_BASE_DOMAIN"
 TEMP=$(mktemp /tmp/superhub.XXXXXX) || exit 1
 # shellcheck disable=SC2064
 trap "rm -f $TEMP" EXIT
@@ -37,7 +37,7 @@ HTTP_CODE=$( \
       -w "%{http_code}" \
       -o "$TEMP" \
       -H 'Content-Type: application/json;charset=UTF-8' \
-      -d "{\"baseDomain\": \"$HUB_PARENT_DOMAIN\"}" \
+      -d "{\"baseDomain\": \"$HUB_BASE_DOMAIN\"}" \
 )
 
 # checking if http code is 2**

--- a/bubble-dns/new
+++ b/bubble-dns/new
@@ -7,7 +7,7 @@
 
 # shellcheck disable=SC2046,SC2086
 
-HUB_PARENT_DOMAIN="epam.devops.delivery"
+HUB_PARENT_DOMAIN="${HUB_PARENT_DOMAIN:-"epam.devops.delivery"}"
 while [ "$1" != "" ]; do
   case $1 in
     --parent-domain )   shift

--- a/bubble-dns/new-name
+++ b/bubble-dns/new-name
@@ -7,11 +7,11 @@
 
 # shellcheck disable=SC2046,SC2086
 
-HUB_PARENT_DOMAIN="${HUB_PARENT_DOMAIN:-"epam.devops.delivery"}"
+HUB_BASE_DOMAIN="${HUB_BASE_DOMAIN:-"epam.devops.delivery"}"
 while [ "$1" != "" ]; do
   case $1 in
     --parent-domain )   shift
-                        HUB_PARENT_DOMAIN="$1"
+                        HUB_BASE_DOMAIN="$1"
                         ;;
   esac
   shift
@@ -31,7 +31,7 @@ HTTP_CODE=$( \
       -w "%{http_code}" \
       -o "$TEMP" \
       -H 'Content-Type: application/json;charset=UTF-8' \
-      -d "{\"baseDomain\": \"$HUB_PARENT_DOMAIN\"}" \
+      -d "{\"baseDomain\": \"$HUB_BASE_DOMAIN\"}" \
 )
 
 # checking if http code is 2**

--- a/bubble-dns/new-name
+++ b/bubble-dns/new-name
@@ -7,7 +7,7 @@
 
 # shellcheck disable=SC2046,SC2086
 
-HUB_PARENT_DOMAIN="epam.devops.delivery"
+HUB_PARENT_DOMAIN="${HUB_PARENT_DOMAIN:-"epam.devops.delivery"}"
 while [ "$1" != "" ]; do
   case $1 in
     --parent-domain )   shift

--- a/hub-show
+++ b/hub-show
@@ -61,10 +61,9 @@ FORMAT="${FORMAT:-yaml}"
 hub_state=
 while [ "$1" != "" ]; do
     case $1 in
-        -c | --component )  deprecated "argument $1 $2" "hubctl show $1"
+        -c | --component )  deprecated "argument $1 $2" "hubctl show $2"
                             shift
-                            hub_state="$1"
-                            deprecated
+                            component="$1"
                             ;;
         -s | --state )      shift
                             hub_state="$1"


### PR DESCRIPTION
This PR contains some small fixes in utils placed under `bin` directory:
- Fixed typo in the parsing of `--color` argument of color util
- Fixed parsing of deprecated argument `--component` of hub-show after new syntax was introduced
- Added possibility to set new dns-bubble endpoint by defining envvar `HUB_BASE_DOMAIN` (HUB_PARENT_DOMAIN is renamed to HUB_BASE_DOMAIN) 