### PR TITLE
Make kubernetes configure idempotent

### DIFF
--- a/bin/kubeconfig
+++ b/bin/kubeconfig
@@ -55,23 +55,23 @@ while [ "$1" != "" ]; do
       ACTION="$1"
       PARAMETER="$2"
       shift
-      ;;
+    ;;
     --kubeconfig | -f )
       shift
       KUBECONFIG="$1"
       export KUBECONFIG
-      ;;
+    ;;
     -c | --kubecontext )
       shift
       KUBECONTEXT="$1"
-      ;;
+    ;;
     --name | -n )
       shift
       HUB_DOMAIN_NAME="$1"
-      ;;
+    ;;
     -p | --print-outputs )
       PRINT_OUTPUTS="1"
-      ;;
+    ;;
     -e | --error )
       fail="1"
     ;;
@@ -100,7 +100,7 @@ test_cluster() {
 ktx_username() {
   # shellcheck disable=SC2016
   kubectl config view --raw -o json 2>/dev/null \
-  | $jq --arg ktx "$1" '.contexts[] | select(.name == $ktx).context.user'
+    | $jq --arg ktx "$1" '.contexts[] | select(.name == $ktx).context.user'
 }
 
 ktx_cluster_name() {
@@ -112,7 +112,7 @@ ktx_cluster_name() {
 ktx_user_json_by_name() {
   # shellcheck disable=SC2016
   kubectl config view --raw -o json 2>/dev/null  \
-  | $jq --arg name "$1" '.users[] | select(.name == $name)'
+    | $jq --arg name "$1" '.users[] | select(.name == $name)'
 }
 
 ktx_cluster_json_by_name() {
@@ -194,19 +194,23 @@ EOF
 
 extract_kubecontext() {
   # Should we test before extract?
-  _extract_kubecontext_cluster_name=
-  _extract_kubecontext_user_name=
   _extract_kubecontext_new_ktx_name=
   if test -n "$2"; then
     _extract_kubecontext_new_ktx_name="$2"
   else
     _extract_kubecontext_new_ktx_name="$1"
   fi
-
   _extract_kubecontext_cluster_name="$(ktx_cluster_name $1)"
+  if test -z "$_extract_kubecontext_cluster_name"; then
+    _extract_kubecontext_cluster_name="$(ktx_cluster_name $2)"
+  fi
   _extract_kubecontext_user_name="$(ktx_username $1)"
+  if test -z "$_extract_kubecontext_user_name"; then
+    _extract_kubecontext_user_name="$(ktx_username $2)"
+  fi
+
   if test -n "$_extract_kubecontext_cluster_name" -a -n "$_extract_kubecontext_user_name"; then
-    cat <<EOF | $jq > $OUTPUT
+    cat <<EOF | $jq > $3
 {
   "kind": "Config",
   "apiVersion": "v1",
@@ -219,7 +223,7 @@ extract_kubecontext() {
   ],
   "contexts": [
     {
-      "name": "$2",
+      "name": "$_extract_kubecontext_new_ktx_name",
       "context": {
         "cluster": "$_extract_kubecontext_cluster_name",
         "user": "$_extract_kubecontext_user_name"

--- a/kubernetes/configure
+++ b/kubernetes/configure
@@ -75,21 +75,18 @@ if test -z "$KUBECONTEXT"; then
   KUBECONTEXT="_"
 fi
 
-if
-    test -n "$HUB_KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG" \
-    && kubeconfig cp -e -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG" -o "$TEMP" > /dev/null 2>&1; then
+if test -f "$HUB_KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG"; then
   printf "* Using kubeconfig from env: "
   color b "HUB_KUBECONFIG"
-elif
-    test -n "$KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$KUBECONFIG" \
-    && kubeconfig cp -e -c "$KUBECONTEXT" -f "$KUBECONFIG" -o "$TEMP" > /dev/null 2>&1; then
+  kubeconfig cp -e -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG" -o "$TEMP" > /dev/null 2>&1
+elif test -f "$KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$KUBECONFIG"; then
   printf "* Using kubeconfig from env: "
   color b "KUBECONFIG"
-elif kubeconfig test -c "$KUBECONTEXT" -f "$HOME/.kube/config" \
-    && kubeconfig cp -e -c "$KUBECONTEXT" -f "$HOME/.kube/config" -o "$TEMP" > /dev/null 2>&1; then : #pass
+  kubeconfig cp -e -c "$KUBECONTEXT" -f "$KUBECONFIG" -o "$TEMP" > /dev/null 2>&1
+elif test -f "$HOME/.kube/config" && kubeconfig test -c "$KUBECONTEXT" -f "$HOME/.kube/config"; then : #pass
   printf "* Using kubeconfig from default location: "
-  # shellcheck disable=SC2016
-  color b '$HOME/.kube/config'
+  color b "\$HOME/.kube/config"
+  kubeconfig cp -e -c "$KUBECONTEXT" -f "$HOME/.kube/config" -o "$TEMP" > /dev/null 2>&1
 elif $(dirname $0)/configure-local-sa --save-to "$TEMP"; then : #pass
   printf "* Using kubeconfig service account"
 else


### PR DESCRIPTION
This PR fixes the issue with the Kubernetes `configure` extensions when in some cases a sequential run of it clears `kubeconfig` file related to a stack in `.hub/env/` directory. The root cause of such behavior was the wrong detection of the current kubecontext, leading to an empty cluster name and username.
