### PR TITLE
Add arg to find-in-path subcommand to find dirs

### DIFF
--- a/bin/files
+++ b/bin/files
@@ -16,7 +16,7 @@ Parameters:
   --help                  Print this message
 
 Subcommands:
-  $(basename "$0") find-in-path FILE             Returns file locatin in PATH (also can use subdirs)
+  $(basename "$0") find-in-path FILE             Returns files/dirs location in PATH (also can use subdirs)
   $(basename "$0") abspath      FILE             Returns returns absolute location for desired file
   $(basename "$0") relpath      TARGET SOURCE    Returns relative path from source to target
   $(basename "$0") download     URL  DEST        Downloads a remote file
@@ -24,23 +24,27 @@ Subcommands:
   $(basename "$0") download-tar URL  EXTRACT_TO  Downlaods and extracts tarball file
 
 Parameters for download-tar:
-  --tar-subpath PATH_INSIDE_TARBALL              Instructs to extract only specific subpath
+  --tar-subpath PATH_INSIDE_TARBALL  Instructs to extract only specific subpath
+Parameters for find-in-path:
+  --dir                              Search for directories in PATH
 EOF
 }
 
 err=false
 op=""
 arg=""
+find_in_path_isdir="false"
 while test -n "$1"; do
   case $1 in
     -h | --help )
         usage
-        exit ;;
+        exit
+    ;;
     -e | --fail | --error )
         shift
         err=true
         continue
-        ;;
+    ;;
     -V | --verbose )
         shift
         set -x
@@ -51,6 +55,11 @@ while test -n "$1"; do
         shift
         arg="$1"
         shift
+        continue
+    ;;
+    --dir )
+        shift
+        find_in_path_isdir="true"
         continue
     ;;
     download | copy | relpath )
@@ -64,7 +73,6 @@ while test -n "$1"; do
         fi
         continue
     ;;
-
     download-tarball | download-tar )
       op="download-tarball"
       shift
@@ -80,7 +88,7 @@ while test -n "$1"; do
       color e "Error: unknown flag $1"
       usage
       exit 1
-      ;;
+    ;;
   esac
   shift
 done
@@ -141,7 +149,10 @@ find_in_path() {
   _file="$(echo "$1" | sed -e 's/^\///')"
   ( IFS=:
     for _path in $PATH; do
-      if test -x "$_path/$_file"; then
+      if test -f "$_path/$_file" -a -x "$_path/$_file"; then
+        rv="$_path/$_file"
+        break;
+      elif test -d "$_path/$_file" -a "$find_in_path_isdir" = "true"; then
         rv="$_path/$_file"
         break;
       fi

--- a/hub-configure
+++ b/hub-configure
@@ -299,7 +299,7 @@ See: https://hubctl.io/hubctl/cli/hubctl-stack-deploy/#executors"
   ask env HUB_DEPLOY_PROFILE -m "executor" -a "hub.executor" --suggest "local" --brief "$BRIEF"
 fi
 
-if files find-in-path "profiles/$HUB_DEPLOY_PROFILE" -e >/dev/null; then
+if files find-in-path "profiles/$HUB_DEPLOY_PROFILE" --dir -e >/dev/null; then
   echo "* Deployment profile: $HUB_DEPLOY_PROFILE"
 else
   color e "Error: cannot find executor: $HUB_DEPLOY_PROFILE" | ident


### PR DESCRIPTION
This PR fixes the issue when an extension is looking for a script to execute by its name but finds a directory that contains target scrips. Examples are before and after scripts in elaborate extension or looking for an executer script.