### PR TITLE
Fix stack backup extension

### DIFF
--- a/hub-stack-backup-create
+++ b/hub-stack-backup-create
@@ -7,6 +7,7 @@
 
 HUB_HOME="${HUB_HOME:-$(dirname "$0")}"
 HUB_WORKDIR="${HUB_WORKDIR:-$(pwd)}"
+HUB_MANUAL_ELABORATE="${HUB_MANUAL_ELABORATE:-"1"}"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
@@ -46,7 +47,7 @@ if test ! -f "$HUB_WORKDIR/.env"; then
 fi
 eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
-FULL_STACK=true
+FULL_STACK="true"
 HUB_OPTS=
 
 while test "$1" != ""; do
@@ -56,7 +57,7 @@ while test "$1" != ""; do
                             ;;
         -c | --component )  shift
                             HUB_OPTS="$HUB_OPTS -c $1"
-                            FULL_STACK=false
+                            FULL_STACK="false"
                             ;;
         --tty )             HUB_OPTS="$HUB_OPTS --tty true"
                             ;;
@@ -122,24 +123,26 @@ if test -n "$HUB_CLOUD_PROVIDER"; then
   HUB_OPTS="--clouds=$HUB_CLOUD_PROVIDER $HUB_OPTS"
 fi
 
-script_dir=$(dirname "$0")
-
-if $FULL_STACK || test -n "$HUB_ELABORATE_FILE" -a ! -e "$HUB_ELABORATE_FILE"; then
-  "$script_dir"/hub-stack-elaborate
+if test "$FULL_STACK" = "true" || test -n "$HUB_ELABORATE_FILE" -a ! -e "$HUB_ELABORATE_FILE"; then
+  hub-stack-elaborate
 elif test -n "$HUB_ELABORATE_FILE"; then
-  if ! "$script_dir"/check-elaborate "$HUB_ELABORATE_FILE" "$HUB_FILES"; then
-    echo "Call:"
-    echo "    $ hubctl stack elaborate"
-    echo "or update elaborate file timestamp:"
-    echo "    $ touch $HUB_ELABORATE_FILE"
-    echo
-    exit 1
+  if ! check-elaborate "$HUB_ELABORATE_FILE" "$HUB_FILES"; then
+    if test -z "$HUB_MANUAL_ELABORATE"; then
+      echo    "Run this command:"
+      color h "    hubctl stack elaborate"
+      echo    "or update elaborate file timestamp:"
+      echo    "    touch $HUB_ELABORATE_FILE"
+      echo
+      exit 1
+    fi
+    hub-stack-elaborate
   fi
 fi
 
-# export HUB_YAML HUB_FILES HUB_STATE HUB_ELABORATE
 if test -z "$HUB_BACKUP_DIR"; then
   HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
+else
+  HUB_BACKUP_DIR=$(files abspath "$HUB_BACKUP_DIR")
 fi
 
 hub_backup_dir="$HUB_BACKUP_DIR"

--- a/hub-stack-backup-elaborate
+++ b/hub-stack-backup-elaborate
@@ -84,6 +84,8 @@ EOF
 
 if test -z "$HUB_BACKUP_DIR"; then
   HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
+else
+  HUB_BACKUP_DIR=$(files abspath "$HUB_BACKUP_DIR")
 fi
 
 # maybe tag?

--- a/hub-stack-backup-ls
+++ b/hub-stack-backup-ls
@@ -43,7 +43,7 @@ EOF
   for d in "$working_dir"/*; do
     if test ! -d "$d"; then continue; fi
     tags="$(find_tags "$d")"
-    if test "$elaborated" == "$(files abspath "$d")"; then
+    if test -n "$elaborated" -a "$elaborated" = "$(files abspath "$d")"; then
       star="*"
     else
       star=" "

--- a/hub-stack-backup-show
+++ b/hub-stack-backup-show
@@ -68,6 +68,8 @@ fi
 
 if test -z "$HUB_BACKUP_DIR"; then
   HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
+else
+  HUB_BACKUP_DIR=$(files abspath "$HUB_BACKUP_DIR")
 fi
 
 backup_path="$HUB_BACKUP_DIR/$HUB_DOMAIN_NAME/$HUB_BACKUP_NAME"

--- a/hub-stack-backup-tag
+++ b/hub-stack-backup-tag
@@ -72,6 +72,8 @@ fi
 
 if test -z "$HUB_BACKUP_DIR"; then
   HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
+else
+  HUB_BACKUP_DIR=$(files abspath "$HUB_BACKUP_DIR")
 fi
 
 if test -z "$HUB_BACKUP_TAG"; then

--- a/hub-stack-backup-untag
+++ b/hub-stack-backup-untag
@@ -59,6 +59,8 @@ eval "$(dotenv export -f "$HUB_WORKDIR/.env")"
 
 if test -z "$HUB_BACKUP_DIR"; then
   HUB_BACKUP_DIR="$HUB_WORKDIR/.hub/backups"
+else
+  HUB_BACKUP_DIR=$(files abspath "$HUB_BACKUP_DIR")
 fi
 
 tag_path="$HUB_BACKUP_DIR/tags/$HUB_BACKUP_TAG"


### PR DESCRIPTION
This PR introduces small fixes to stack backup extension

- Fix usage of util check-elaborate in backup create
- Get the abs path of HUB_BACKUP_DIR if it's defined in .env file 