### PR TITLE
Unbundle backup directly to file

### DIFF
--- a/hub-stack-restore
+++ b/hub-stack-restore
@@ -118,7 +118,7 @@ fi
 backup_params="$(mktemp)"
 trap 'rm -f $backup_params' EXIT
 
-hubctl backup unbundle "$hub_bundle" > "$backup_params"
+hubctl backup unbundle "$hub_bundle" --output="$backup_params" --compressed=false
 
 if test ! -s "$backup_params"; then
   color e "Error: Unable to get backup parameters"

--- a/hub-stack-restore
+++ b/hub-stack-restore
@@ -35,7 +35,7 @@ Parameters:
 EOF
 }
 
-HUB_OPTS=""
+HUB_OPTS="--compressed=false"
 HUB_COMPONENT=""
 VERBOSE=${VERBOSE:-""}
 
@@ -49,10 +49,10 @@ while test -n "$1"; do
           HUB_COMPONENT="$1"
           ;;
         --tty )
-          HUB_OPTS="$HUB_OPTS --tty true"
+          HUB_OPTS="$HUB_OPTS --tty=true"
           ;;
         --no-tty )
-          HUB_OPTS="$HUB_OPTS --tty false"
+          HUB_OPTS="$HUB_OPTS --tty=false"
           ;;
         -V | --verbose )
           VERBOSE="--verbose"
@@ -118,7 +118,8 @@ fi
 backup_params="$(mktemp)"
 trap 'rm -f $backup_params' EXIT
 
-hubctl backup unbundle "$hub_bundle" --output="$backup_params" --compressed=false
+# shellcheck disable=SC2086
+hubctl backup unbundle "$hub_bundle" --output="$backup_params" $HUB_OPTS
 
 if test ! -s "$backup_params"; then
   color e "Error: Unable to get backup parameters"


### PR DESCRIPTION
To avoid https://github.com/mikefarah/yq/issues/1896 issue unbundle backup to file instead of redirecting stdout to file. 