### PR TITLE
KUBECONFIG holds a list of kubeconfig files

### DIFF
--- a/bin/kubeconfig
+++ b/bin/kubeconfig
@@ -243,11 +243,6 @@ if test "$VERBOSE" = "true"; then
   set -x
 fi
 
-if test ! -f "$KUBECONFIG"; then
-  echo "* Error kubeconfig: $KUBECONFIG (not found)"
-  if test -n "$fail"; then exit 1; fi
-fi
-
 if test "$KUBECONTEXT" = "_"; then
   KUBECONTEXT="$(kubectl config current-context 2>/dev/null)"
   if test -z "$KUBECONTEXT"; then

--- a/kubernetes/configure
+++ b/kubernetes/configure
@@ -75,15 +75,15 @@ if test -z "$KUBECONTEXT"; then
   KUBECONTEXT="_"
 fi
 
-if test -f "$HUB_KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG"; then
+if test -n "$HUB_KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG"; then
   printf "* Using kubeconfig from env: "
   color b "HUB_KUBECONFIG"
   kubeconfig cp -e -c "$KUBECONTEXT" -f "$HUB_KUBECONFIG" -o "$TEMP" > /dev/null 2>&1
-elif test -f "$KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$KUBECONFIG"; then
+elif test -n "$KUBECONFIG" && kubeconfig test -c "$KUBECONTEXT" -f "$KUBECONFIG"; then
   printf "* Using kubeconfig from env: "
   color b "KUBECONFIG"
   kubeconfig cp -e -c "$KUBECONTEXT" -f "$KUBECONFIG" -o "$TEMP" > /dev/null 2>&1
-elif test -f "$HOME/.kube/config" && kubeconfig test -c "$KUBECONTEXT" -f "$HOME/.kube/config"; then : #pass
+elif test -f "$HOME/.kube/config" && kubeconfig test -c "$KUBECONTEXT" -f "$HOME/.kube/config"; then
   printf "* Using kubeconfig from default location: "
   color b "\$HOME/.kube/config"
   kubeconfig cp -e -c "$KUBECONTEXT" -f "$HOME/.kube/config" -o "$TEMP" > /dev/null 2>&1


### PR DESCRIPTION
The env var `KUBECONFIG` holds a list of kubeconfig files. In that case, it's useless to test it as single file.
https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/#the-kubeconfig-environment-variable