### PR TITLE
Fix replacing comma on Mac

### DIFF
--- a/hub-stack-restore
+++ b/hub-stack-restore
@@ -145,5 +145,5 @@ echo "$HUB_COMPONENT" | while read -r component; do
     continue
   fi
 
-  hub-stack-invoke "$component" restore -e "$(echo "$env_vars" | head -c -2)" "$VERBOSE"
+  hub-stack-invoke "$component" restore -e "$(echo "${env_vars%,}")" "$VERBOSE"
 done


### PR DESCRIPTION
Head command was replaced in order to support operation on mac