### PR TITLE
Trim leading trailing spaces from HUB_FILES env var

### DIFF
--- a/hub-configure
+++ b/hub-configure
@@ -11,10 +11,6 @@ HUB_EXTENSION="$(basename "$0" | sed -e 's/hub-/hubctl-/g' -e 's/-/ /g')"
 PATH="$HUB_HOME:$HUB_HOME/bin:$HUB_WORKDIR:$HUB_WORKDIR/bin:$PATH"
 export PATH
 
-ident() {
-  sed 's/^/  /'
-}
-
 usage() {
   cat << EOF
 Reads configuration information in ${HUB_FILES:-hub.yaml} and configures stack for deployment.
@@ -50,16 +46,6 @@ EOF
     fi
     $_usage_configure --help
   done
-}
-
-real_files() {
-  # shellcheck disable=SC2068
-  for f in $@; do
-    if test -f "$f"; then
-      printf " %s" "$f"
-    fi
-  done
-  echo
 }
 
 VERBOSE=false
@@ -127,6 +113,20 @@ done
 if $VERBOSE; then
   set -x
 fi
+
+ident() {
+  sed 's/^/  /'
+}
+
+real_files() {
+  # shellcheck disable=SC2068
+  for f in $@; do
+    if test -f "$f"; then
+      printf " %s" "$f"
+    fi
+  done
+  echo
+}
 
 TEMP_FILES=""
 temp_file(){
@@ -241,7 +241,7 @@ if $HELP; then
 fi
 
 # shellcheck disable=SC2086
-HUB_FILES="$(real_files $HUB_FILES)"
+HUB_FILES="$(real_files $HUB_FILES | xargs)"
 export HUB_FILES
 trap 'finalize $?' EXIT
 
@@ -316,5 +316,5 @@ fi
 
 if ! dotenv contains "HUB_ELABORATE"; then
   echo "* Setting hubctl elaborate to local file"
-  dotenv set  "HUB_ELABORATE" "$(files abspath "$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate")"
+  dotenv set "HUB_ELABORATE" "$(files abspath "$HUB_WORKDIR/.hub/$HUB_DOMAIN_NAME.elaborate")"
 fi

--- a/hub-stack-init
+++ b/hub-stack-init
@@ -17,53 +17,6 @@ export HUB_WORKDIR
 
 KNOWN_URLS=""
 
-is_url() {
-  echo "$1" | grep -e '[[:alnum:]]*://' >/dev/null 2>&1
-}
-
-get_filepath() {
-  if is_url "$1"; then
-    echo "$HUB_WORKDIR/$(basename "$f")"
-  else
-    echo "$1"
-  fi
-}
-
-maybe_download() {
-  filepath="$(get_filepath "$1")"
-  if test -f "$filepath"; then
-    echo "(exists)"
-  elif is_url "$1"; then
-    files download "$1" "$filepath"
-    echo "(downloaded)"
-    KNOWN_URLS=$(dirname "$1" | xargs)
-  else
-    for url in $KNOWN_URLS; do
-      # shellcheck disable=SC2001
-      if files download "$url/$1" "$HUB_WORKDIR/$1"; then
-        echo "(downloaded)"
-        break
-      fi
-    done
-  fi
-  test -f "$filepath"
-}
-
-
-real_files() {
-  # shellcheck disable=SC2068
-  for f in $@; do
-    if test -f "$f"; then
-      printf " %s" "$f"
-    fi
-  done
-  echo
-}
-
-toJson() {
-  yq e -NM -o=json "$1"
-}
-
 # shellcheck disable=SC2120
 usage() {
   cat << EOF
@@ -103,17 +56,6 @@ Flags:
   -V, --verbose               Verbose outputs for debug purposes
   -h, --help                  Print this message
 EOF
-}
-
-ident() {
-  sed 's/^/  /'
-}
-
-finalize() {
-  rv="$?"
-  # shellcheck disable=SC2068
-  rm -rf $@
-  exit $rv
 }
 
 VERBOSE=false
@@ -165,8 +107,66 @@ if $VERBOSE; then
   set -x
 fi
 
+ident() {
+  sed 's/^/  /'
+}
+
+finalize() {
+  rv="$?"
+  # shellcheck disable=SC2068
+  rm -rf $@
+  exit $rv
+}
+
+is_url() {
+  echo "$1" | grep -e '[[:alnum:]]*://' >/dev/null 2>&1
+}
+
+get_filepath() {
+  if is_url "$1"; then
+    echo "$HUB_WORKDIR/$(basename "$f")"
+  else
+    echo "$1"
+  fi
+}
+
+maybe_download() {
+  filepath="$(get_filepath "$1")"
+  if test -f "$filepath"; then
+    echo "(exists)"
+  elif is_url "$1"; then
+    files download "$1" "$filepath"
+    echo "(downloaded)"
+    KNOWN_URLS=$(dirname "$1" | xargs)
+  else
+    for url in $KNOWN_URLS; do
+      # shellcheck disable=SC2001
+      if files download "$url/$1" "$HUB_WORKDIR/$1"; then
+        echo "(downloaded)"
+        break
+      fi
+    done
+  fi
+  test -f "$filepath"
+}
+
+
+real_files() {
+  # shellcheck disable=SC2068
+  for f in $@; do
+    if test -f "$f"; then
+      printf " %s" "$f"
+    fi
+  done
+  echo
+}
+
+toJson() {
+  yq e -NM -o=json "$1"
+}
+
 if test -z "$HUB_FILES" -a -f "$HUB_WORKDIR/hub.yaml"; then
-  HUB_FILES="$HUB_WORKDIR/hub.yaml"
+  HUB_FILES="hub.yaml"
 fi
 
 if test -f "$HUB_WORKDIR/.env" -a -z "$HUB_USE_FORCE"; then
@@ -404,9 +404,9 @@ if test -n "$SOURCE_HUB_STATE"; then
       exit 13
     fi
     if test -s "$temp"; then
-      state_status="$(${hubctl} explain "${temp}" --json | jq -cMr '.status | select(.)')"
+      state_status="$(hubctl explain "${temp}" --json | jq -cMr '.status | select(.)')"
       echo "  State status: ${state_status}"
-      state_msg="$(${hubctl} explain "${temp}" --json | jq -cMr '.message | select(.)')"
+      state_msg="$(hubctl explain "${temp}" --json | jq -cMr '.message | select(.)')"
       if test -n "${state_msg}"; then
         echo "  Message: ${state_msg}"
       fi


### PR DESCRIPTION
The main change is to remove leading trailing spaces from `HUB_FILES` env var on `hubctl stack configure`.
Small improvements were introduced as well:

- Move some functions after `set +x` to improve verbosity
- Remove adding of `HUB_WORKDIR` to `hub.yaml` file on `hubctl stack init`
- Couple of typos